### PR TITLE
Test-based Filtering Implementation

### DIFF
--- a/app/HooglePlus.hs
+++ b/app/HooglePlus.hs
@@ -26,7 +26,8 @@ import Synquid.Util (showme)
 import HooglePlus.Synthesize
 import HooglePlus.Stats
 import Types.Encoder
-import PetriNet.GHCChecker
+import HooglePlus.GHCChecker
+import HooglePlus.Utils
 
 import Control.Monad
 import Control.Lens ((^.))
@@ -90,6 +91,7 @@ main = do
                   , disable_relevancy
                   , disable_copy_trans
                   , disable_blacklist
+                  , disable_filter
                   } -> do
             let searchParams =
                     defaultSearchParams
@@ -107,6 +109,7 @@ main = do
                         , _disableRelevancy = disable_relevancy
                         , _disableCopy = disable_copy_trans
                         , _disableBlack = disable_blacklist
+                        , _disableFilter = disable_filter
                         }
             let synquidParams =
                     defaultSynquidParams {Main.envPath = env_file_path_in}
@@ -158,7 +161,8 @@ data CommandLineArgs
         coalescing_strategy :: CoalesceStrategy,
         disable_relevancy :: Bool,
         disable_copy_trans :: Bool,
-        disable_blacklist :: Bool
+        disable_blacklist :: Bool,
+        disable_filter :: Bool
       }
       | Generate {
         -- | Input
@@ -190,7 +194,8 @@ synt = Synthesis {
   coalescing_strategy = First &= help ("Choose how type coalescing works. Default: Pick first element of each group set."),
   disable_relevancy   = False           &= help ("Disable the relevancy requirement for argument types (default: False)"),
   disable_copy_trans  = False           &= help ("Disable the copy transitions and allow more than one token in initial state instead (default: False)"),
-  disable_blacklist     = False         &= help ("Disable blacklisting functions in the solution (default: False)")
+  disable_blacklist     = False         &= help ("Disable blacklisting functions in the solution (default: False)"),
+  disable_filter      = False           &= help ("Disable filter-based test")
   } &= auto &= help "Synthesize goals specified in the input file"
 
 generate = Generate {

--- a/benchmark/BOutput.hs
+++ b/benchmark/BOutput.hs
@@ -7,7 +7,7 @@ import Synquid.Util
 import Types.Experiments
 import Types.Environment
 import Types.Generate
-import PetriNet.GHCChecker (toHaskellSolution)
+import HooglePlus.Utils
 
 import qualified Data.Map as Map
 import qualified Data.Set as Set

--- a/benchmark/Runner.hs
+++ b/benchmark/Runner.hs
@@ -8,7 +8,7 @@ import Types.Experiments
 import Synquid.Util
 import HooglePlus.Synthesize
 import Database.Environment
-import PetriNet.GHCChecker (toHaskellSolution, printSolution)
+import HooglePlus.Utils
 
 import System.Timeout
 import Control.Exception

--- a/package.yaml
+++ b/package.yaml
@@ -61,6 +61,7 @@ dependencies:
 - unordered-containers
 - vector
 - uuid
+- QuickCheck
 
 library:
   source-dirs:

--- a/src/HooglePlus/FilterTest.hs
+++ b/src/HooglePlus/FilterTest.hs
@@ -155,7 +155,8 @@ runChecks' modules funcSig body = handleNotSupported executeCheck
         Nothing -> putStrLn "Timeout in running always-fail detection" >> return True
         Just (Left err) -> putStrLn (displayException err) >> return False
         -- `seq` used to evaluate res, thus raise the exception on always-fail
-        Just (Right res) -> seq res (pure ()) >> return True
+        Just (Right res) -> handleAnyException (seq res (pure ()) >> return True)
 
 handleNotSupported = (`catch` ((\ex -> print ex >> return True) :: NotSupportedException -> IO Bool))
+handleAnyException = (`catch` ((\ex -> return False) :: SomeException -> IO Bool))
 fmtFunction_ = printf "((%s) :: %s) %s" :: String -> String -> String -> String

--- a/src/HooglePlus/FilterTest.hs
+++ b/src/HooglePlus/FilterTest.hs
@@ -1,0 +1,85 @@
+module HooglePlus.FilterTest (runGhcChecks, getTypeString, runNoExceptionTest) where
+
+import Language.Haskell.Interpreter
+import Language.Haskell.Exts.Parser
+import Text.Printf
+import Control.Exception
+import Data.List
+import Language.Haskell.Exts.SrcLoc
+import Language.Haskell.Exts.Syntax
+import Language.Haskell.Exts.Pretty
+
+import Test.QuickCheck
+
+data ArgumentType = Instance String | Polymorphic String deriving (Show)
+
+getTypeString :: String -> IO (Either InterpreterError String)
+getTypeString input =
+  runInterpreter $ do {
+    setImports ["Prelude", "Data.List", "Data.Maybe"];
+    typeOf input
+  }
+
+-- todo: qualified type support
+parseTypeString :: String -> ([ArgumentType], ArgumentType)
+parseTypeString input = buildRet [] value
+  where
+    (ParseOk value) = parseType input
+
+    argName (TyVar _ (Ident _ name)) = Polymorphic name
+    argName (TyCon _ (UnQual _ (Ident _ name))) = Instance name
+    argName (TyList _ arg) =
+      case argName arg of Instance n -> Instance ("[" ++ n ++ "]")
+                          Polymorphic n -> Polymorphic ("[" ++ n ++ "]")
+    
+    -- todo: e.g. map numeric value to Int
+    argName (TyForall _ _ _ t) = error $ show t
+
+    buildRet argList (TyFun _ typeArg typeRet) = buildRet (argList ++ [argName typeArg]) typeRet
+    buildRet argList typeRet = (argList, argName typeRet)
+
+
+-- todo: implement
+runGhcChecks :: String -> IO Bool
+runGhcChecks input = return False 
+
+generatePrimitiveTestData :: String -> IO String
+generatePrimitiveTestData pType = 
+  let pre str = "(" ++ str ++ ")" in case pType of
+  "Int" ->
+    do result <- generate arbitrary :: IO Int
+       return $ pre $ show result
+  "Bool" ->
+    do result <- generate arbitrary :: IO Bool
+       return $ pre $ show result
+  "String" ->
+    do result <- generate arbitrary :: IO String
+       return $ pre $ format $ show result
+    where
+      format str = prettyPrint (String [] str "")
+
+-- todo: support for list/custom data types
+prepareArguments :: String-> IO String
+prepareArguments input =
+  do
+    (Right typeStr) <- getTypeString input
+    unwords <$> mapM f (fst $ parseTypeString typeStr)
+  where
+    f (Instance x) = generatePrimitiveTestData x
+    f (Polymorphic x) = generatePrimitiveTestData "Int"
+
+runNoExceptionTest :: String -> IO Bool
+runNoExceptionTest input =
+  let
+    importList = ["Prelude", "Data.List", "Data.Maybe"]
+    code = "(" ++ input ++ ")"
+  in do
+    arg <- prepareArguments input
+    result <- runInterpreter $ do {
+      setImports importList;
+      eval (code ++ " " ++ arg)
+    }
+    case result of
+      Left err -> putStrLn (displayException err) >> return False
+      Right res -> putStrLn res >> return True
+

--- a/src/HooglePlus/FilterTest.hs
+++ b/src/HooglePlus/FilterTest.hs
@@ -129,20 +129,20 @@ generateTestInput' imports (constraints, args, retType) = mapM f (transformType 
       where
         args' = map (replace envItem) args
 
-        replace (Polymorphic name, cons) (Polymorphic name') =
-          if name == name' then
-            case cons of
+        -- replace all occurrance of nameL to its instantiated type
+        replace (Polymorphic nameL, constraint) (Polymorphic nameR) =
+          if nameL == nameR then
+            case constraint of
               "Eq" -> Concrete "Int"
               "Num" -> Concrete "Int"
-          else Polymorphic name'
-        replace cons (ArgTypeList argType) = ArgTypeList (replace cons argType)
+          else Polymorphic nameR
+        replace constraint (ArgTypeList argType) = ArgTypeList (replace constraint argType)
         replace _ x = x
 
 eval_ :: [String] -> String -> Int -> IO (Maybe (Either InterpreterError String))
-eval_ modules line time = timeout time $ runInterpreter $ do {
-  setImports modules;
+eval_ modules line time = timeout time $ runInterpreter $ do
+  setImports modules
   eval line
-}
 
 runChecks :: Environment -> RType -> UProgram -> IO Bool
 runChecks env goalType prog = do

--- a/src/HooglePlus/GHCChecker.hs
+++ b/src/HooglePlus/GHCChecker.hs
@@ -117,6 +117,8 @@ parseStrictnessSig result = let
 checkStrictness :: Int -> String -> String -> [String] -> IO Bool
 checkStrictness tyclassCount body sig modules = handle (\(SomeException _) -> return False) (checkStrictness' tyclassCount body sig modules)
 
+-- validate type signiture, run demand analysis, and run filter test
+-- checks the end result type checks; all arguments are used; and that the program will not immediately fail
 runGhcChecks :: SearchParams -> Environment -> RType -> UProgram -> IO Bool
 runGhcChecks params env goalType prog = let
     -- constructs program and its type signature as strings
@@ -133,7 +135,7 @@ runGhcChecks params env goalType prog = let
     expr = body ++ " :: " ++ funcSig
     disableDemand = _disableDemand params
     disableFilter = _disableFilter params
-    in do --
+    in do
         typeCheckResult <- runInterpreter $ checkType expr modules
         strictCheckResult <- if disableDemand then return True else checkStrictness tyclassCount body funcSig modules
         filterCheckResult <- if disableFilter then return True else runChecks env goalType prog

--- a/src/HooglePlus/GHCChecker.hs
+++ b/src/HooglePlus/GHCChecker.hs
@@ -1,17 +1,18 @@
-module PetriNet.GHCChecker (
-    runGhcChecks, mkFunctionSigStr, mkLambdaStr,
-    removeTypeclasses, toHaskellSolution,
-    parseStrictnessSig, checkStrictness', printSolution) where
+module HooglePlus.GHCChecker (
+    runGhcChecks, parseStrictnessSig, checkStrictness') where
 
 import Language.Haskell.Interpreter
 
 import Types.Environment
 import Types.Program
 import Types.Type
+import Types.Experiments
 import Synquid.Type
 import Synquid.Util hiding (fromRight)
 import Synquid.Pretty as Pretty
 import Database.Util
+import HooglePlus.Utils
+import HooglePlus.FilterTest (runChecks)
 
 import Control.Exception
 import Control.Monad.Trans
@@ -116,8 +117,8 @@ parseStrictnessSig result = let
 checkStrictness :: Int -> String -> String -> [String] -> IO Bool
 checkStrictness tyclassCount body sig modules = handle (\(SomeException _) -> return False) (checkStrictness' tyclassCount body sig modules)
 
-runGhcChecks :: Bool -> Environment -> RType -> UProgram -> IO Bool
-runGhcChecks disableDemand env goalType prog = let
+runGhcChecks :: SearchParams -> Environment -> RType -> UProgram -> IO Bool
+runGhcChecks params env goalType prog = let
     -- constructs program and its type signature as strings
     args = _arguments env
     modules = Set.toList $ _included_modules env
@@ -130,13 +131,16 @@ runGhcChecks disableDemand env goalType prog = let
     argTypesMap = Map.fromList $ zip (argNames) (map show monoGoals)
     body = mkLambdaStr argNames prog
     expr = body ++ " :: " ++ funcSig
-    in do
+    disableDemand = _disableDemand params
+    disableFilter = _disableFilter params
+    in do --
         typeCheckResult <- runInterpreter $ checkType expr modules
         strictCheckResult <- if disableDemand then return True else checkStrictness tyclassCount body funcSig modules
+        filterCheckResult <- if disableFilter then return True else runChecks env goalType prog
         case typeCheckResult of
             Left err -> (putStrLn $ displayException err) >> return False
             Right False -> (putStrLn "Program does not typecheck") >> return False
-            Right True -> return strictCheckResult
+            Right True -> return $ strictCheckResult && filterCheckResult
 
 -- ensures that the program type-checks
 checkType :: String -> [String] -> Interpreter Bool
@@ -145,65 +149,3 @@ checkType expr modules = do
     -- Ensures that if there's a problem we'll know
     Language.Haskell.Interpreter.typeOf expr
     typeChecks expr
-
--- Converts the list of param types into a haskell function signature.
--- Moves typeclass-looking things to the front in a context.
-mkFunctionSigStr :: [RType] -> String
-mkFunctionSigStr args = addConstraints $ Prelude.foldr accumConstraints ([],[]) args
-    where
-        showSigs sigs = intercalate " -> " sigs
-        addConstraints ([], baseSigs) = showSigs baseSigs
-        addConstraints (constraints, baseSigs) = "(" ++ (intercalate ", " constraints) ++ ") => " ++ showSigs baseSigs
-
-        accumConstraints :: RType -> ([String], [String]) -> ([String], [String])
-        accumConstraints (ScalarT (DatatypeT id [ScalarT (TypeVarT _ tyvarName) _] _) _) (constraints, baseSigs)
-            | tyclassPrefix `isPrefixOf` id = let
-                classNameRegex = mkRegex $ tyclassPrefix ++ "([a-zA-Z]*)"
-                className = subRegex classNameRegex id "\\1"
-                constraint = className ++ " " ++ tyvarName
-                -- \(@@hplusTC@@([a-zA-Z]*) \(([a-z]*)\)\)
-                in
-                    (constraint:constraints, baseSigs)
-        accumConstraints otherTy (constraints, baseSigs) = (constraints, show otherTy:baseSigs)
-
--- mkLambdaStr produces a oneline lambda expr str:
--- (\x -> \y -> body))
-mkLambdaStr :: [String] -> UProgram -> String
-mkLambdaStr args body = let
-    unTypeclassed = toHaskellSolution (show body)
-    in
-        unwords . words . show $ foldr addFuncArg (text unTypeclassed) args
-    where
-        addFuncArg arg rest
-            | "arg" `isPrefixOf` arg = Pretty.parens $ text ("\\" ++ arg ++ " -> ") <+> rest
-            | otherwise = rest
-
-removeAll :: Regex -> String -> String
-removeAll a b = unwords $ words $ go a b
-    where
-        go regex input =
-            if (isJust $ matchRegex regex input)
-            then (go regex $ subRegex regex input "")
-            else input
-
-removeTypeclassArgs :: String -> String
-removeTypeclassArgs = removeAll (mkRegex (tyclassArgBase++"[0-9]+\\s?"))
-
-removeTypeclassInstances :: String -> String
-removeTypeclassInstances = removeAll (mkRegex (tyclassInstancePrefix ++ "[0-9]*[a-zA-Z]*"))
-
-removeTypeclasses = removeEmptyParens . removeTypeclassArgs . removeTypeclassInstances
-    where
-        removeEmptyParens = removeAll (mkRegex "\\(\\s+\\)")
-
-toHaskellSolution :: String -> String
-toHaskellSolution bodyStr = let
-    oneLineBody = unwords $ lines bodyStr
-    noTypeclasses = (removeTypeclasses) oneLineBody
-    in
-        noTypeclasses
-
-printSolution solution = do
-    putStrLn "*******************SOLUTION*********************"
-    putStrLn $ "SOLUTION: " ++ toHaskellSolution (show solution)
-    putStrLn "************************************************"

--- a/src/HooglePlus/Utils.hs
+++ b/src/HooglePlus/Utils.hs
@@ -1,0 +1,102 @@
+module HooglePlus.Utils where
+
+import Types.Environment
+import Types.Program
+import Types.Type
+import Types.Experiments
+import Synquid.Type
+import Synquid.Util hiding (fromRight)
+import Synquid.Pretty as Pretty
+import Database.Util
+
+import Control.Exception
+import Control.Monad.Trans
+import CorePrep
+import CoreSyn
+import Data.Data
+import Data.Either
+import Data.List (isInfixOf, isPrefixOf, intercalate)
+import Data.List.Split (splitOn)
+import Data.Maybe
+import Data.Typeable
+import Demand
+import DmdAnal
+import DynFlags
+import FamInstEnv
+import GHC
+import GHC.Paths ( libdir )
+import HscTypes
+import IdInfo
+import Outputable hiding (text, (<+>))
+import qualified CoreSyn as Syn
+import qualified Data.Map as Map hiding (map, foldr)
+import qualified Data.Set as Set hiding (map)
+import qualified Data.Text as Text
+import SimplCore (core2core)
+import System.Directory (removeFile)
+import Text.Printf
+import Text.Regex
+import Var
+import Data.UUID.V4
+
+-- Converts the list of param types into a haskell function signature.
+-- Moves typeclass-looking things to the front in a context.
+mkFunctionSigStr :: [RType] -> String
+mkFunctionSigStr args = addConstraints $ Prelude.foldr accumConstraints ([],[]) args
+    where
+        showSigs sigs = intercalate " -> " sigs
+        addConstraints ([], baseSigs) = showSigs baseSigs
+        addConstraints (constraints, baseSigs) = "(" ++ (intercalate ", " constraints) ++ ") => " ++ showSigs baseSigs
+
+        accumConstraints :: RType -> ([String], [String]) -> ([String], [String])
+        accumConstraints (ScalarT (DatatypeT id [ScalarT (TypeVarT _ tyvarName) _] _) _) (constraints, baseSigs)
+            | tyclassPrefix `isPrefixOf` id = let
+                classNameRegex = mkRegex $ tyclassPrefix ++ "([a-zA-Z]*)"
+                className = subRegex classNameRegex id "\\1"
+                constraint = className ++ " " ++ tyvarName
+                -- \(@@hplusTC@@([a-zA-Z]*) \(([a-z]*)\)\)
+                in
+                    (constraint:constraints, baseSigs)
+        accumConstraints otherTy (constraints, baseSigs) = (constraints, show otherTy:baseSigs)
+
+-- mkLambdaStr produces a oneline lambda expr str:
+-- (\x -> \y -> body))
+mkLambdaStr :: [String] -> UProgram -> String
+mkLambdaStr args body = let
+    unTypeclassed = toHaskellSolution (show body)
+    in
+        unwords . words . show $ foldr addFuncArg (text unTypeclassed) args
+    where
+        addFuncArg arg rest
+            | "arg" `isPrefixOf` arg = Pretty.parens $ text ("\\" ++ arg ++ " -> ") <+> rest
+            | otherwise = rest
+
+toHaskellSolution :: String -> String
+toHaskellSolution bodyStr = let
+    oneLineBody = unwords $ lines bodyStr
+    noTypeclasses = (removeTypeclasses) oneLineBody
+    in
+        noTypeclasses
+
+removeAll :: Regex -> String -> String
+removeAll a b = unwords $ words $ go a b
+    where
+        go regex input =
+            if (isJust $ matchRegex regex input)
+            then (go regex $ subRegex regex input "")
+            else input
+
+removeTypeclassArgs :: String -> String
+removeTypeclassArgs = removeAll (mkRegex (tyclassArgBase++"[0-9]+\\s?"))
+
+removeTypeclassInstances :: String -> String
+removeTypeclassInstances = removeAll (mkRegex (tyclassInstancePrefix ++ "[0-9]*[a-zA-Z]*"))
+
+removeTypeclasses = removeEmptyParens . removeTypeclassArgs . removeTypeclassInstances
+    where
+        removeEmptyParens = removeAll (mkRegex "\\(\\s+\\)")
+
+printSolution solution = do
+    putStrLn "*******************SOLUTION*********************"
+    putStrLn $ "SOLUTION: " ++ toHaskellSolution (show solution)
+    putStrLn "************************************************"

--- a/src/PetriNet/PNSolver.hs
+++ b/src/PetriNet/PNSolver.hs
@@ -680,7 +680,7 @@ findProgram env dst st ps
         disableDemand <- getExperiment disableDemand
         disableRele <- getExperiment disableRelevancy
         params <- gets $ view searchParams
-        checkedSols <- -- todo: filter-tests went here?
+        checkedSols <-
             withTime
                 TypeCheckTime
                 (filterM (liftIO . runGhcChecks params env dst) [code'])

--- a/src/PetriNet/PNSolver.hs
+++ b/src/PetriNet/PNSolver.hs
@@ -35,7 +35,7 @@ import HooglePlus.CodeFormer
 import HooglePlus.Refinement
 import HooglePlus.Stats
 import PetriNet.AbstractType
-import PetriNet.GHCChecker
+import HooglePlus.GHCChecker
 import PetriNet.PNEncoder
 import PetriNet.Util
 import Synquid.Error
@@ -679,10 +679,11 @@ findProgram env dst st ps
         let code' = recoverNames mapping code
         disableDemand <- getExperiment disableDemand
         disableRele <- getExperiment disableRelevancy
-        checkedSols <-
+        params <- gets $ view searchParams
+        checkedSols <- -- todo: filter-tests went here?
             withTime
                 TypeCheckTime
-                (filterM (liftIO . runGhcChecks (disableRele || disableDemand) env dst) [code'])
+                (filterM (liftIO . runGhcChecks params env dst) [code'])
         if (code' `elem` solutions) || null checkedSols
             then return Nothing
             else return $ Just code'

--- a/src/Types/Experiments.hs
+++ b/src/Types/Experiments.hs
@@ -46,7 +46,8 @@ data SearchParams = SearchParams {
   _coalesceStrategy :: CoalesceStrategy,
   _disableRelevancy :: Bool,
   _disableCopy :: Bool,
-  _disableBlack :: Bool
+  _disableBlack :: Bool,
+  _disableFilter :: Bool
 } deriving (Eq, Show)
 
 makeLenses ''SearchParams
@@ -93,7 +94,8 @@ defaultSearchParams = SearchParams {
   _coalesceStrategy = First,
   _disableRelevancy = False,
   _disableCopy = False,
-  _disableBlack = False
+  _disableBlack = False,
+  _disableFilter = False
 }
 
 type ExperimentName = String

--- a/src/Types/Filtering.hs
+++ b/src/Types/Filtering.hs
@@ -3,6 +3,7 @@ module Types.Filtering where
 import Control.Exception
 import Data.Typeable
 import Text.Printf
+import Data.List (intercalate)
 
 data ArgumentType =
     Concrete String
@@ -12,7 +13,7 @@ data ArgumentType =
 
 instance Show ArgumentType where
   show (Concrete name) = name
-  show (Polymorphic _) = "Int"
+  show (Polymorphic name) = name
   show (ArgTypeList sub) = printf "[%s]" (show sub)
 
 newtype NotSupportedException = NotSupportedException String
@@ -20,8 +21,23 @@ newtype NotSupportedException = NotSupportedException String
 
 instance Exception NotSupportedException
 
-type TypeConstraints = [(ArgumentType, String)]
-type FunctionSigniture = (TypeConstraints, [ArgumentType], ArgumentType)
+data TypeConstraint = TypeConstraint String String
+
+instance Show TypeConstraint where
+  show (TypeConstraint name constraint) = printf "%s %s" constraint name
+
+data FunctionSignature =
+  FunctionSignature { _constraints :: [TypeConstraint]
+                    , _argsType :: [ArgumentType]
+                    , _returnType :: ArgumentType
+  }
+
+instance Show FunctionSignature where
+  show (FunctionSignature constraints argsType returnType) = 
+    printf "(%s) => %s" constraintsExpr argsExpr
+      where
+        constraintsExpr = (intercalate ", " . map show) constraints
+        argsExpr = (intercalate " -> " . map show) (argsType ++ [returnType])
 
 defaultTimeout = 3000000 :: Int
 defaultNumChecks = 10 :: Int

--- a/src/Types/Filtering.hs
+++ b/src/Types/Filtering.hs
@@ -1,0 +1,24 @@
+module Types.Filtering where
+
+import Control.Exception
+import Data.Typeable
+import Text.Printf
+
+data ArgumentType =
+    Concrete String
+  | Polymorphic String
+  | ArgTypeList ArgumentType
+  deriving (Eq)
+
+instance Show ArgumentType where
+  show (Concrete name) = name
+  show (Polymorphic _) = "Int"
+  show (ArgTypeList sub) = printf "[%s]" (show sub)
+
+newtype NotSupportedException = NotSupportedException String
+  deriving (Show, Typeable)
+
+instance Exception NotSupportedException
+
+type TypeConstraints = [(ArgumentType, String)]
+type FunctionSigniture = (TypeConstraints, [ArgumentType], ArgumentType)

--- a/src/Types/Filtering.hs
+++ b/src/Types/Filtering.hs
@@ -22,3 +22,6 @@ instance Exception NotSupportedException
 
 type TypeConstraints = [(ArgumentType, String)]
 type FunctionSigniture = (TypeConstraints, [ArgumentType], ArgumentType)
+
+defaultTimeout = 3000000 :: Int
+defaultNumChecks = 10 :: Int

--- a/src/Types/Filtering.hs
+++ b/src/Types/Filtering.hs
@@ -6,15 +6,20 @@ import Text.Printf
 import Data.List (intercalate)
 
 data ArgumentType =
-    Concrete String
+    Concrete    String
   | Polymorphic String
   | ArgTypeList ArgumentType
+  | ArgTypeTuple [ArgumentType]
+  | ArgTypeApp  ArgumentType ArgumentType
   deriving (Eq)
 
 instance Show ArgumentType where
-  show (Concrete name) = name
+  show (Concrete    name) = name
   show (Polymorphic name) = name
-  show (ArgTypeList sub) = printf "[%s]" (show sub)
+  show (ArgTypeList sub)  = printf "[%s]" (show sub)
+  show (ArgTypeApp  l r)  = printf "(%s) %s"  (show l) (show r)
+  show (ArgTypeTuple types) = 
+    (printf "(%s)" . intercalate ", " . map show) types
 
 newtype NotSupportedException = NotSupportedException String
   deriving (Show, Typeable)

--- a/test/HooglePlus/FilterTestSpec.hs
+++ b/test/HooglePlus/FilterTestSpec.hs
@@ -1,0 +1,52 @@
+module HooglePlus.FilterTestSpec (spec) where
+
+
+import Test.Hspec
+import Text.Pretty.Simple
+import Text.Parsec.Pos
+import Control.Monad.State
+import Text.Parsec.Indent
+import qualified Data.Map as Map
+import Data.Either
+
+import HooglePlus.FilterTest
+
+spec :: Spec
+spec =
+  describe "Filter" $ do
+
+  it "Return Correct Type" $ do
+    result <- getTypeString "\\x -> [x]"
+    case result of
+      Left err -> error "failed"
+      Right str -> str `shouldBe` "a -> [a]"
+  
+  it "Succeed on poly function w/o type constrains" $ do
+    result <- runNoExceptionTest "\\x -> x"
+    result `shouldBe` True
+
+  it "Pass function w/ different retval - singleList" $ do
+    result <- runGhcChecks "\\x -> [x]"
+    result `shouldBe` True
+
+  it "Pass function w/ different retval - headLast" $ do
+    result <- runGhcChecks "\\x -> (head x, last x)"
+    result `shouldBe` True
+
+  it "Fail on invalid fcns - head []" $ do
+    result <- runGhcChecks "\\x -> (head x, last [])"
+    result `shouldBe` False
+
+  it "Fail on invalid fcns - just nothing" $ do
+    result <- runGhcChecks "\\x -> fromJust Nothing"
+    result `shouldBe` False
+
+  it "Fail on const fcns" $ do
+    result <- runGhcChecks "\\x -> \\y -> const x y"
+    result `shouldBe` False
+
+
+
+
+-- quickCheckWith stdArgs{replay = Just (mkQCGen 4, 0)}
+-- stack test --test-arguments "--match /HooglePlus.FilterTest/Filter"

--- a/test/HooglePlus/FilterTestSpec.hs
+++ b/test/HooglePlus/FilterTestSpec.hs
@@ -11,12 +11,14 @@ import Data.Either
 
 import HooglePlus.FilterTest
 
+importList = ["Prelude", "Data.List", "Data.Maybe"]
+
 spec :: Spec
 spec =
   describe "Filter" $ do
 
   it "Return Correct Type" $ do
-    result <- getTypeString "\\x -> [x]"
+    result <- getTypeString importList "\\x -> [x]"
     case result of
       Left err -> error "failed"
       Right str -> str `shouldBe` "a -> [a]"

--- a/test/HooglePlus/GHCCheckerSpec.hs
+++ b/test/HooglePlus/GHCCheckerSpec.hs
@@ -1,6 +1,7 @@
-module PetriNet.GHCCheckerSpec (spec) where
+module HooglePlus.GHCCheckerSpec (spec) where
 
-import PetriNet.GHCChecker
+import HooglePlus.GHCChecker
+import HooglePlus.Utils
 import Synquid.Parser
 import Synquid.Pretty () -- Instances
 import Types.Type


### PR DESCRIPTION
Just realized that I forgot to create the PR. Sorry for the delay!

What's working now:
- Filter out solutions that would always fail
- Duplicated solutions -- but not yet integrated to the H+ command line (will do once the message channel between `H+ <-> Checker` is established)

Unsupported solutions would be directly passed (basically HOFs)

Update: Fixed for pairs/custom data constructors. Ready to be reviewed now.