### PR TITLE
Fix timeout handler, add more unit tests

### DIFF
--- a/src/HooglePlus/FilterTest.hs
+++ b/src/HooglePlus/FilterTest.hs
@@ -164,5 +164,8 @@ runChecks' modules sigString body = handleNotSupported executeCheck
         Just (Right ()) -> return True
 
 handleNotSupported = (`catch` ((\ex -> print ex >> return True) :: NotSupportedException -> IO Bool))
-handleAnyException = (`catch` ((\ex -> return $ Just $ Left $ UnknownError $ show ex) :: SomeException -> IO (Maybe (Either InterpreterError ()))))
+handleAnyException = (`catch` (return . handler . show :: SomeException -> IO (Maybe (Either InterpreterError ()))))
+  where
+    handler ex  | "timeout" `isInfixOf` ex = Nothing
+                | otherwise = (Just . Left. UnknownError) ex
 fmtFunction_ = printf "((%s) :: %s) %s" :: String -> String -> String -> String

--- a/src/HooglePlus/FilterTest.hs
+++ b/src/HooglePlus/FilterTest.hs
@@ -55,8 +55,8 @@ parseTypeString input = FunctionSignature constraints argsType returnType
 -- instantiate polymorphic types in function signature with `Int`
 -- * note that constraints were ignored since we only use `Int` now
 instantiateSignature :: FunctionSignature -> FunctionSignature
-instantiateSignature (FunctionSignature constraints argsType returnType) =
-  FunctionSignature constraints (map instantiate argsType) (instantiate returnType)
+instantiateSignature (FunctionSignature _ argsType returnType) =
+  FunctionSignature [] (map instantiate argsType) (instantiate returnType)
     where
       instantiate (Concrete name) = Concrete name
       instantiate (Polymorphic name) = Concrete "Int"

--- a/test/HooglePlus/FilterTestSpec.hs
+++ b/test/HooglePlus/FilterTestSpec.hs
@@ -12,53 +12,29 @@ import Data.Either
 import HooglePlus.FilterTest
 
 modules = ["Prelude"]
-
 runTest modules' = runChecks' (modules' ++ modules)
+
+itCase :: (String, [String], String, String, Bool) -> SpecWith (Arg (IO ()))
+itCase (desc, modules, funcSig, body, expectedRetVal) =
+  it desc $ do
+    result <- runTest modules funcSig body
+    result `shouldBe` expectedRetVal
+
+testCases :: [(String, [String], String, String, Bool)]
+testCases = 
+  [("Succeed on poly function w/o type constrains 1", [], "a -> a", "\\x -> x", True)
+  , ("Succeed on poly function w/o type constrains 2", [], "(a, b) -> b", "\\(x, y) -> y", True)
+  , ("Succeed on poly function w/o type constrains 3", [], "(a, Either Int Int) -> Int", "\\(_, t) -> either id id t", True)
+  , ("Succeed on infinite functions", ["GHC.List"], "a -> [a]", "\\x -> repeat x", True)
+  , ("Succeed on var w/ module names", ["GHC.Int", "Data.ByteString.Lazy", "Data.ByteString.Builder"], 
+     "GHC.Int.Int64 -> Data.ByteString.Lazy.ByteString",
+     "\\arg0 -> Data.ByteString.Builder.toLazyByteString (Data.ByteString.Builder.int64Dec arg0)", True)
+  , ("Fail on invalid function 1", ["Data.Maybe"], "a -> a", "\\x -> fromJust Nothing", False)
+  , ("Fail on invalid function 2", ["Data.List"], "a -> a", "\\x -> head []", False)
+  , ("Fail on invalid function 3", ["Data.List"], "a -> (a, a)", "\\x -> (head [x], last [])", False)
+  , ("Fail on invalid function 5", ["Data.Maybe"], "Either a b -> Maybe a", "\\x -> fromJust Nothing", False)
+  , ("Pass w/ type class 1", [], "(Show a, Show b) => Either a b -> String", "\\x -> show x", True)]
 
 spec :: Spec
 spec =
-  describe "Filter" $ do
-
-  it "Succeed on poly function w/o type constrains 1" $ do
-    result <- runTest [] "a -> a" "\\x -> x"
-    result `shouldBe` True
-  
-  it "Succeed on poly function w/o type constrains 2" $ do
-    result <- runTest [] "(a, b) -> b" "\\(x, y) -> y"
-    result `shouldBe` True
-
-  it "Succeed on poly function w/o type constrains 3" $ do
-    result <- runTest [] "(a, Either Int Int) -> Int" "\\(_, t) -> either id id t"
-    result `shouldBe` True
-  
-  it "Succeed on infinite functions" $ do
-    result <- runTest ["GHC.List"] "a -> [a]" "\\x -> repeat x"
-    result `shouldBe` True
-
-  it "Succeed on var w/ module names" $ do
-    result <- runTest ["GHC.Int", "Data.ByteString.Lazy", "Data.ByteString.Builder"] "GHC.Int.Int64 -> Data.ByteString.Lazy.ByteString" "\\arg0 -> Data.ByteString.Builder.toLazyByteString (Data.ByteString.Builder.int64Dec arg0)"
-    result `shouldBe` True
-
-  it "Fail on invalid function 1" $ do
-    result <- runTest ["Data.Maybe"] "a -> a" "\\x -> fromJust Nothing"
-    result `shouldBe` False
-
-  it "Fail on invalid function 2" $ do
-    result <- runTest ["Data.List"] "a -> a" "\\x -> head []"
-    result `shouldBe` False
-
-  it "Fail on invalid function 3" $ do
-    result <- runTest ["Data.List"] "a -> (a, a)" "\\x -> (head [x], last [])"
-    result `shouldBe` False
-
-  it "Fail on invalid function 4" $ do
-    result <- runTest ["Data.List"] "a -> (a, a)" "\\x -> (head [x], last [])"
-    result `shouldBe` False
-
-  it "Fail on invalid function 5" $ do
-    result <- runTest ["Data.Maybe"] "Either a b -> Maybe a" "\\x -> fromJust Nothing"
-    result `shouldBe` False
-  
-  it "Pass w/ type class 1" $ do
-    result <- runTest [] "(Show a, Show b) => Either a b -> String" "\\x -> show x"
-    result `shouldBe` True
+  describe "Filter" $ mapM_ itCase testCases

--- a/test/HooglePlus/FilterTestSpec.hs
+++ b/test/HooglePlus/FilterTestSpec.hs
@@ -19,8 +19,20 @@ spec :: Spec
 spec =
   describe "Filter" $ do
 
-  it "Succeed on poly function w/o type constrains" $ do
+  it "Succeed on poly function w/o type constrains 1" $ do
     result <- runTest [] "a -> a" "\\x -> x"
+    result `shouldBe` True
+  
+  it "Succeed on poly function w/o type constrains 2" $ do
+    result <- runTest [] "(a, b) -> b" "\\(x, y) -> y"
+    result `shouldBe` True
+
+  it "Succeed on poly function w/o type constrains 3" $ do
+    result <- runTest [] "(a, Either Int Int) -> Int" "\\(_, t) -> either id id t"
+    result `shouldBe` True
+  
+  it "Succeed on infinite functions" $ do
+    result <- runTest ["GHC.List"] "a -> [a]" "\\x -> repeat x"
     result `shouldBe` True
 
   it "Succeed on var w/ module names" $ do
@@ -31,10 +43,18 @@ spec =
     result <- runTest ["Data.Maybe"] "a -> a" "\\x -> fromJust Nothing"
     result `shouldBe` False
 
-  it "Fail on invalid function 1" $ do
+  it "Fail on invalid function 2" $ do
     result <- runTest ["Data.List"] "a -> a" "\\x -> head []"
     result `shouldBe` False
 
-  it "Fail on invalid function 2" $ do
+  it "Fail on invalid function 3" $ do
     result <- runTest ["Data.List"] "a -> (a, a)" "\\x -> (head [x], last [])"
+    result `shouldBe` False
+
+  it "Fail on invalid function 4" $ do
+    result <- runTest ["Data.List"] "a -> (a, a)" "\\x -> (head [x], last [])"
+    result `shouldBe` False
+
+  it "Fail on invalid function 6" $ do
+    result <- runTest ["Data.Maybe"] "Either a b -> Maybe a" "\\x -> fromJust Nothing"
     result `shouldBe` False

--- a/test/HooglePlus/FilterTestSpec.hs
+++ b/test/HooglePlus/FilterTestSpec.hs
@@ -55,6 +55,10 @@ spec =
     result <- runTest ["Data.List"] "a -> (a, a)" "\\x -> (head [x], last [])"
     result `shouldBe` False
 
-  it "Fail on invalid function 6" $ do
+  it "Fail on invalid function 5" $ do
     result <- runTest ["Data.Maybe"] "Either a b -> Maybe a" "\\x -> fromJust Nothing"
     result `shouldBe` False
+  
+  it "Pass w/ type class 1" $ do
+    result <- runTest [] "(Show a, Show b) => Either a b -> String" "\\x -> show x"
+    result `shouldBe` True


### PR DESCRIPTION
Due to unknown reason, when the execution of the interpreter exceed our timeout, `timeout` function won't return `Nothing`. Instead, it would raise an exception with message `<<timeout>>`. 

This PR modifies the exception handler to return `Nothing` in case of such timeout exception and adds more unit tests for functions that involve *data type construction* and _timeout_.

update:
- fixed an issue where type classes prevent type resolution after instantiating polymorphic functions