### PR TITLE
Implement duplicate check for test-based filter

### DIFF
--- a/src/HooglePlus/FilterTest.hs
+++ b/src/HooglePlus/FilterTest.hs
@@ -186,7 +186,10 @@ checkDuplicates' result modules sigStr body =
       evals <- evalResults inputs funcSig body
       let isDuplicated = evals `elem` results
       let results' = if isDuplicated then results else evals:results
-      return (not isDuplicated, Sample inputs results')
+
+      let retVal = (not isDuplicated, Sample inputs results')
+      print retVal
+      return retVal
 
   where
     funcSig = (instantiateSignature . parseTypeString) sigStr

--- a/src/HooglePlus/GHCChecker.hs
+++ b/src/HooglePlus/GHCChecker.hs
@@ -7,6 +7,7 @@ import Types.Environment
 import Types.Program
 import Types.Type
 import Types.Experiments
+import Types.Filtering
 import Synquid.Type
 import Synquid.Util hiding (fromRight)
 import Synquid.Pretty as Pretty
@@ -119,7 +120,7 @@ checkStrictness tyclassCount body sig modules = handle (\(SomeException _) -> re
 
 -- validate type signiture, run demand analysis, and run filter test
 -- checks the end result type checks; all arguments are used; and that the program will not immediately fail
-runGhcChecks :: SearchParams -> Environment -> RType -> UProgram -> IO Bool
+runGhcChecks :: MonadIO m => SearchParams -> Environment -> RType -> UProgram -> FilterTest m Bool
 runGhcChecks params env goalType prog = let
     -- constructs program and its type signature as strings
     (modules, funcSig, body, argList) = extractSolution env goalType prog
@@ -128,12 +129,12 @@ runGhcChecks params env goalType prog = let
     disableDemand = _disableDemand params
     disableFilter = _disableFilter params
     in do
-        typeCheckResult <- runInterpreter $ checkType expr modules
-        strictCheckResult <- if disableDemand then return True else checkStrictness tyclassCount body funcSig modules
+        typeCheckResult <- liftIO $ runInterpreter $ checkType expr modules
+        strictCheckResult <- if disableDemand then return True else liftIO $ checkStrictness tyclassCount body funcSig modules
         filterCheckResult <- if disableFilter then return True else runChecks env goalType prog
         case typeCheckResult of
-            Left err -> (putStrLn $ displayException err) >> return False
-            Right False -> (putStrLn "Program does not typecheck") >> return False
+            Left err -> liftIO $ putStrLn (displayException err) >> return False
+            Right False -> liftIO $ putStrLn "Program does not typecheck" >> return False
             Right True -> return $ strictCheckResult && filterCheckResult
 
 -- ensures that the program type-checks

--- a/src/PetriNet/PNSolver.hs
+++ b/src/PetriNet/PNSolver.hs
@@ -682,10 +682,10 @@ findProgram env dst st ps
         disableRele <- getExperiment disableRelevancy
         params <- gets $ view searchParams
         fState <- gets $ view filterState
-        (checkResult, fState') <-
+        (passedCheck, fState') <-
             withTime TypeCheckTime (liftIO $ runStateT (runGhcChecks params env dst code') fState)
         modify $ set filterState fState'
-        if (code' `elem` solutions) || not checkResult
+        if (code' `elem` solutions) || not passedCheck
             then return Nothing
             else return $ Just code'
 

--- a/src/Types/Filtering.hs
+++ b/src/Types/Filtering.hs
@@ -1,6 +1,7 @@
 module Types.Filtering where
 
 import Control.Exception
+import Control.Monad.State
 import Data.Typeable
 import Text.Printf
 import Data.List (intercalate)
@@ -53,8 +54,11 @@ data SampleResult = SampleResult
   deriving (Eq, Show)
 
 data FilterState = FilterState
-  { _sampleResults :: Maybe SampleResult }
+  { sampleResults :: Maybe SampleResult }
+  deriving (Eq)
 
 emptyFilterState = FilterState {
-  _sampleResults = Nothing
+  sampleResults = Nothing
 }
+
+type FilterTest m = StateT FilterState m

--- a/src/Types/Filtering.hs
+++ b/src/Types/Filtering.hs
@@ -8,7 +8,7 @@ import Data.List (intercalate)
 
 defaultTimeoutMicro = 1 * 10^6 :: Int
 defaultNumChecks = 10 :: Int
-defaultEvalLength = 100 :: Int
+defaultMaxOutputLength = 100 :: Int
 
 data ArgumentType =
     Concrete    String
@@ -55,7 +55,7 @@ data SampleResult = SampleResult
 
 data FilterState = FilterState
   { sampleResults :: Maybe SampleResult }
-  deriving (Eq)
+  deriving (Eq, Show)
 
 emptyFilterState = FilterState {
   sampleResults = Nothing

--- a/src/Types/Filtering.hs
+++ b/src/Types/Filtering.hs
@@ -5,7 +5,7 @@ import Data.Typeable
 import Text.Printf
 import Data.List (intercalate)
 
-defaultTimeout = 1000000 :: Int
+defaultTimeoutMicro = 1 * 10^6 :: Int
 defaultNumChecks = 10 :: Int
 defaultEvalLength = 100 :: Int
 
@@ -22,7 +22,7 @@ instance Show ArgumentType where
   show (Polymorphic name) = name
   show (ArgTypeList sub)  = printf "[%s]" (show sub)
   show (ArgTypeApp  l r)  = printf "(%s) %s"  (show l) (show r)
-  show (ArgTypeTuple types) = 
+  show (ArgTypeTuple types) =
     (printf "(%s)" . intercalate ", " . map show) types
 
 newtype NotSupportedException = NotSupportedException String
@@ -42,14 +42,19 @@ data FunctionSignature =
   }
 
 instance Show FunctionSignature where
-  show (FunctionSignature constraints argsType returnType) = 
+  show (FunctionSignature constraints argsType returnType) =
     printf "(%s) => %s" constraintsExpr argsExpr
       where
         constraintsExpr = (intercalate ", " . map show) constraints
         argsExpr = (intercalate " -> " . map show) (argsType ++ [returnType])
 
-data SampleResult =
-    Sample { _inputs :: [String]
-           , _results :: [[String]]}
-  | EmptySample
+data SampleResult = SampleResult
+  { _inputs :: [String], _results :: [[String]]}
   deriving (Eq, Show)
+
+data FilterState = FilterState
+  { _sampleResults :: Maybe SampleResult }
+
+emptyFilterState = FilterState {
+  _sampleResults = Nothing
+}

--- a/src/Types/Filtering.hs
+++ b/src/Types/Filtering.hs
@@ -5,6 +5,10 @@ import Data.Typeable
 import Text.Printf
 import Data.List (intercalate)
 
+defaultTimeout = 1000000 :: Int
+defaultNumChecks = 10 :: Int
+defaultEvalLength = 100 :: Int
+
 data ArgumentType =
     Concrete    String
   | Polymorphic String
@@ -44,5 +48,8 @@ instance Show FunctionSignature where
         constraintsExpr = (intercalate ", " . map show) constraints
         argsExpr = (intercalate " -> " . map show) (argsType ++ [returnType])
 
-defaultTimeout = 3000000 :: Int
-defaultNumChecks = 10 :: Int
+data SampleResult =
+    Sample { _inputs :: [String]
+           , _results :: [[String]]}
+  | EmptySample
+  deriving (Eq, Show)

--- a/src/Types/Solver.hs
+++ b/src/Types/Solver.hs
@@ -51,7 +51,7 @@ data SolverState = SolverState {
     _toRemove :: [Id],
     _useCount :: Map Id Int,
     _messageChan :: Chan Message,
-    _sampleResult :: Maybe SampleResult
+    _filterState :: FilterState
 } deriving(Eq)
 
 
@@ -83,7 +83,7 @@ emptySolverState = SolverState {
     _toRemove = [],
     _useCount = Map.empty,
     _messageChan = undefined,
-    _sampleResult = Nothing 
+    _filterState = emptyFilterState
 }
 
 makeLenses ''SolverState

--- a/src/Types/Solver.hs
+++ b/src/Types/Solver.hs
@@ -17,6 +17,7 @@ import Types.Experiments hiding (PetriNet)
 import Types.Type
 import Types.Common
 import Types.Encoder
+import Types.Filtering
 
 rootNode = AScalar (ATypeVarT varName)
 pairProj = "pair_match"
@@ -49,7 +50,8 @@ data SolverState = SolverState {
     _instanceCounts :: HashMap Id Int, -- Number of instantiations for a real-name, used in selecting representative
     _toRemove :: [Id],
     _useCount :: Map Id Int,
-    _messageChan :: Chan Message
+    _messageChan :: Chan Message,
+    _sampleResult :: SampleResult
 } deriving(Eq)
 
 
@@ -80,7 +82,8 @@ emptySolverState = SolverState {
     _instanceCounts = HashMap.empty,
     _toRemove = [],
     _useCount = Map.empty,
-    _messageChan = undefined
+    _messageChan = undefined,
+    _sampleResult = EmptySample
 }
 
 makeLenses ''SolverState

--- a/src/Types/Solver.hs
+++ b/src/Types/Solver.hs
@@ -51,7 +51,7 @@ data SolverState = SolverState {
     _toRemove :: [Id],
     _useCount :: Map Id Int,
     _messageChan :: Chan Message,
-    _sampleResult :: SampleResult
+    _sampleResult :: Maybe SampleResult
 } deriving(Eq)
 
 
@@ -83,7 +83,7 @@ emptySolverState = SolverState {
     _toRemove = [],
     _useCount = Map.empty,
     _messageChan = undefined,
-    _sampleResult = EmptySample
+    _sampleResult = Nothing 
 }
 
 makeLenses ''SolverState

--- a/test/HooglePlus/FilterTestSpec.hs
+++ b/test/HooglePlus/FilterTestSpec.hs
@@ -13,16 +13,18 @@ import HooglePlus.FilterTest
 import Types.Filtering
 
 modules = ["Prelude"]
-runTest modules' = runChecks' (modules' ++ modules)
 
-itCase :: (String, [String], String, String, Bool) -> SpecWith (Arg (IO ()))
-itCase (desc, modules, funcSig, body, expectedRetVal) =
+runNotCrashTest modules' funcSig body =
+  evalStateT (checkSolutionNotCrash (modules' ++ modules) funcSig body) emptyFilterState
+
+itNotCrashCase :: (String, [String], String, String, Bool) -> SpecWith (Arg (IO ()))
+itNotCrashCase (desc, modules, funcSig, body, expectedRetVal) =
   it desc $ do
-    result <- runTest modules funcSig body
+    result <- runNotCrashTest modules funcSig body
     result `shouldBe` expectedRetVal
 
-testCases :: [(String, [String], String, String, Bool)]
-testCases =
+testNotCrashCases :: [(String, [String], String, String, Bool)]
+testNotCrashCases =
   [("Succeed on poly function w/o type constrains 1", [], "a -> a", "\\x -> x", True)
   , ("Succeed on poly function w/o type constrains 2", [], "(a, b) -> b", "\\(x, y) -> y", True)
   , ("Succeed on poly function w/o type constrains 3", [], "(a, Either Int Int) -> Int", "\\(_, t) -> either id id t", True)
@@ -36,17 +38,21 @@ testCases =
   , ("Fail on invalid function 5", ["Data.Maybe"], "Either a b -> Maybe a", "\\x -> fromJust Nothing", False)
   , ("Pass w/ type class 1", [], "(Show a, Show b) => Either a b -> String", "\\x -> show x", True)]
 
+runDuplicateTest :: FilterState -> [String] -> String -> String -> IO (Bool, FilterState)
+runDuplicateTest st modules' funcSig body =
+  runStateT (checkDuplicates (modules ++ modules') funcSig body) st
+
 spec :: Spec
 spec =
   describe "Filter" $ do
-    mapM_ itCase testCases
+    mapM_ itNotCrashCase testNotCrashCases
 
     it "Duplicates - pass on base case" $ do
-      (ret, sample) <- checkDuplicates' EmptySample ["Prelude"] "a -> a" "\\x -> x"
+      (ret, (FilterState {sampleResults = sample})) <- runDuplicateTest emptyFilterState [] "a -> a" "\\x -> x"
       ret `shouldBe` True
-      sample `shouldNotBe` EmptySample
+      sample `shouldNotBe` Nothing
 
-      let Sample inputs outputs = sample
+      let Just (SampleResult inputs outputs) = sample
       length inputs `shouldBe` defaultNumChecks
       length outputs `shouldBe` 1
       
@@ -54,19 +60,19 @@ spec =
       length evalResults `shouldBe` defaultNumChecks
 
     it "Duplicates - reject identical solution" $ do
-      (ret, sample) <- checkDuplicates' EmptySample ["Prelude"] "Num a => a -> a" "\\x -> x + 1"
-      (ret', sample') <- checkDuplicates' sample ["Prelude"] "Num a => a -> a" "\\x -> 1 + x"
+      (ret, st) <- runDuplicateTest emptyFilterState [] "Num a => a -> a" "\\x -> x + 1"
+      (ret', st') <- runDuplicateTest st [] "Num a => a -> a" "\\x -> 1 + x"
       
       ret `shouldBe` True
       ret' `shouldBe` False
 
-      sample `shouldBe` sample'
+      (st == st') `shouldBe` True 
 
     it "test - pass valid solution" $ do
-      (ret, sample) <- checkDuplicates' EmptySample ["Prelude"] "[a] -> a" "\\x -> head x"
-      (ret', sample') <- checkDuplicates' sample ["Prelude"] "[a] -> a" "\\x -> last x"
+      (ret, st) <- runDuplicateTest emptyFilterState [] "[a] -> a" "\\x -> head x"
+      (ret', st') <- runDuplicateTest st [] "[a] -> a" "\\x -> last x"
       
       ret `shouldBe` True
       ret' `shouldBe` True
 
-      sample `shouldNotBe` sample'
+      (st == st') `shouldBe` False  

--- a/test/HooglePlus/FilterTestSpec.hs
+++ b/test/HooglePlus/FilterTestSpec.hs
@@ -47,8 +47,8 @@ spec =
   describe "Filter" $ do
     mapM_ itNotCrashCase testNotCrashCases
 
-    it "Duplicates - pass on base case" $ do
-      (ret, (FilterState {sampleResults = sample})) <- runDuplicateTest emptyFilterState [] "a -> a" "\\x -> x"
+    it "Duplicates - generate inputs and pass on base case" $ do
+      (ret, FilterState {sampleResults = sample}) <- runDuplicateTest emptyFilterState [] "a -> a" "\\x -> x"
       ret `shouldBe` True
       sample `shouldNotBe` Nothing
 
@@ -59,20 +59,20 @@ spec =
       let evalResults = head outputs
       length evalResults `shouldBe` defaultNumChecks
 
-    it "Duplicates - reject identical solution" $ do
+    it "Duplicates - reject identical solution and persist the previous state" $ do
       (ret, st) <- runDuplicateTest emptyFilterState [] "Num a => a -> a" "\\x -> x + 1"
       (ret', st') <- runDuplicateTest st [] "Num a => a -> a" "\\x -> 1 + x"
       
       ret `shouldBe` True
       ret' `shouldBe` False
 
-      (st == st') `shouldBe` True 
+      st `shouldBe` st'
 
-    it "test - pass valid solution" $ do
+    it "test - pass valid solution and add solution to the state" $ do
       (ret, st) <- runDuplicateTest emptyFilterState [] "[a] -> a" "\\x -> head x"
       (ret', st') <- runDuplicateTest st [] "[a] -> a" "\\x -> last x"
       
       ret `shouldBe` True
       ret' `shouldBe` True
 
-      (st == st') `shouldBe` False  
+      st `shouldNotBe` st'

--- a/test/HooglePlus/FilterTestSpec.hs
+++ b/test/HooglePlus/FilterTestSpec.hs
@@ -35,7 +35,8 @@ testNotCrashCases =
   , ("Fail on invalid function 1", ["Data.Maybe"], "a -> a", "\\x -> fromJust Nothing", False)
   , ("Fail on invalid function 2", ["Data.List"], "a -> a", "\\x -> head []", False)
   , ("Fail on invalid function 3", ["Data.List"], "a -> (a, a)", "\\x -> (head [x], last [])", False)
-  , ("Fail on invalid function 5", ["Data.Maybe"], "Either a b -> Maybe a", "\\x -> fromJust Nothing", False)
+  , ("Fail on invalid function 4", ["Data.List"], "a -> (a, a)", "\\x -> (head [x], last [])", False)
+  -- , ("Non-deterministic function", [], "Int", "last $ repeat 5", True)
   , ("Pass w/ type class 1", [], "(Show a, Show b) => Either a b -> String", "\\x -> show x", True)]
 
 runDuplicateTest :: FilterState -> [String] -> String -> String -> IO (Bool, FilterState)


### PR DESCRIPTION
- Add functions for checking duplicates
- Basic unit tests for dup-check
- Integrate state for dup-check into `SolverState`
- Change `defaultTimeout` to _1s_ 

It seems the most proper to put all results for solutions we tested into `SolverState`, and thus I have to use the duplicate check outside `runGhcChecks`. Any feedback is appreciated!