### PR TITLE
Fix interpreter running on nondeterministic inputs

### DIFF
--- a/src/HooglePlus/FilterTest.hs
+++ b/src/HooglePlus/FilterTest.hs
@@ -173,11 +173,11 @@ checkSolutionNotCrash modules sigStr body = or <$> liftIO executeCheck
       arg <- generateTestInput modules funcSig
       let expression = fmtFunction_ body (show funcSig) arg
 
-      result <- runStmt_ modules expression defaultTimeoutMicro
+      result <- eval_ modules expression defaultTimeoutMicro
       case result of
         Nothing -> putStrLn "Timeout in running always-fail detection" >> return True
         Just (Left err) -> putStrLn (displayException err) >> return False
-        Just (Right ()) -> return True
+        Just (Right res) -> return (seq res True)
 
 handleNotSupported = (`catch` ((\ex -> print ex >> return []) :: NotSupportedException -> IO [Bool]))
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,15 @@
 packages:
 - .
-resolver: lts-12.4
+resolver: lts-12.26
 extra-deps:
   - table-layout-0.8.0.3
   - data-default-instances-base-0.1.0.1
   - pretty-tree-0.1.0.0
+
+compiler: ghc-8.4.4
+setup-info:
+  ghc:
+    linux64-custom-yields:
+      8.4.4:
+        url: "https://github.com/mistzzt/build-ghc-no-omit-yields/releases/download/v8.4.4/ghc-8.4.4-x86_64-unknown-linux.tar.xz"
+ghc-variant: yields

--- a/test/HooglePlus/FilterTestSpec.hs
+++ b/test/HooglePlus/FilterTestSpec.hs
@@ -36,7 +36,7 @@ testNotCrashCases =
   , ("Fail on invalid function 2", ["Data.List"], "a -> a", "\\x -> head []", False)
   , ("Fail on invalid function 3", ["Data.List"], "a -> (a, a)", "\\x -> (head [x], last [])", False)
   , ("Fail on invalid function 4", ["Data.List"], "a -> (a, a)", "\\x -> (head [x], last [])", False)
-  -- , ("Non-deterministic function", [], "Int", "last $ repeat 5", True)
+  , ("Non-deterministic function", [], "Int", "last $ repeat 5", True)
   , ("Pass w/ type class 1", [], "(Show a, Show b) => Either a b -> String", "\\x -> show x", True)]
 
 runDuplicateTest :: FilterState -> [String] -> String -> String -> IO (Bool, FilterState)


### PR DESCRIPTION
- Introduced prebuilt compiler in `stack.yaml`
- Updated resolve to 12.26 in order to match ghc 8.4.4

The binary distribution of our custom GHC is hosted on GitHub release, where I uploaded the script to generate it [in the repo](https://github.com/mistzzt/build-ghc-no-omit-yields). Discussed below, it seems that publishing the prebuilt binaries is the optimal solution.

The problem of our interpreter running on infinite evaluation like `last $ repeat 5` is discussed here: https://gist.github.com/mistzzt/851f34e36621faeda76608c213442cd8