### PR TITLE
Multithreading support for GHCChecker

### DIFF
--- a/app/HooglePlus.hs
+++ b/app/HooglePlus.hs
@@ -244,9 +244,11 @@ executeSearch :: SynquidParams -> SearchParams  -> String -> IO ()
 executeSearch synquidParams searchParams query = do
   env <- readEnv
   goal <- envToGoal env query
-  messageChan <- newChan
-  worker <- forkIO $ synthesize searchParams goal messageChan
-  readChan messageChan >>= (handleMessages messageChan)
+  solverChan <- newChan
+  checkerChan <- newChan
+  workerS <- forkIO $ synthesize searchParams goal solverChan
+  workerC <- forkIO $ check goal searchParams solverChan checkerChan
+  readChan checkerChan >>= (handleMessages checkerChan)
   return ()
   where
     logLevel = searchParams ^. explorerLogLevel

--- a/package.yaml
+++ b/package.yaml
@@ -83,6 +83,7 @@ executables:
     ghc-options:
     - -rtsopts
     - -O2
+    - -threaded
     dependencies:
     - HooglePlus
   webapp:

--- a/package.yaml
+++ b/package.yaml
@@ -83,7 +83,6 @@ executables:
     ghc-options:
     - -rtsopts
     - -O2
-    - -threaded
     dependencies:
     - HooglePlus
   webapp:

--- a/src/HooglePlus/FilterTest.hs
+++ b/src/HooglePlus/FilterTest.hs
@@ -211,5 +211,7 @@ checkDuplicates modules sigStr body = do
     generateInputs modules funcSig = replicateM defaultNumChecks (generateTestInput modules funcSig)
     evalResults inputs funcSig body = mapM evalWithArg inputs
 
-    evalWithArg arg =
-        show <$> eval_ modules (fmtFunction_ body (show funcSig) arg) defaultTimeoutMicro
+    evalWithArg :: String -> IO SampleResultItem
+    evalWithArg arg = liftM2 (,)
+      (pure arg)
+      (show <$> eval_ modules (fmtFunction_ body (show funcSig) arg) defaultTimeoutMicro)

--- a/src/HooglePlus/FilterTest.hs
+++ b/src/HooglePlus/FilterTest.hs
@@ -173,11 +173,11 @@ checkSolutionNotCrash modules sigStr body = or <$> liftIO executeCheck
       arg <- generateTestInput modules funcSig
       let expression = fmtFunction_ body (show funcSig) arg
 
-      result <- runStmt_ modules expression defaultTimeoutMicro
+      result <- eval_ modules expression defaultTimeoutMicro
       case result of
         Nothing -> putStrLn "Timeout in running always-fail detection" >> return True
         Just (Left err) -> putStrLn (displayException err) >> return False
-        Just (Right ()) -> return True
+        Just (Right res) -> return (seq res True)
 
 handleNotSupported = (`catch` ((\ex -> print ex >> return []) :: NotSupportedException -> IO [Bool]))
 

--- a/src/HooglePlus/FilterTest.hs
+++ b/src/HooglePlus/FilterTest.hs
@@ -1,6 +1,7 @@
 module HooglePlus.FilterTest (runChecks, checkSolutionNotCrash, checkDuplicates) where
 
 import Language.Haskell.Interpreter hiding (get)
+import Language.Haskell.Interpreter.Unsafe
 import Language.Haskell.Exts.Parser
 import Text.Printf
 import Control.Exception
@@ -137,7 +138,7 @@ generateTestInput' imports funcSig = mapM f (_argsType funcSig)
 
 eval_ :: [String] -> String -> Int -> IO (Maybe (Either InterpreterError String))
 eval_ modules line time = handleAnyException $ timeout time $ do
-  result <- runInterpreter $ do
+  result <- unsafeRunInterpreterWithArgs ["-fno-omit-yields"] $ do
     setImports modules
     eval line
   case result of
@@ -147,11 +148,6 @@ eval_ modules line time = handleAnyException $ timeout time $ do
         then (return . Left . UnknownError) val
         else (return . Right) output
     _ -> return result
-
-runStmt_ :: [String] -> String -> Int -> IO (Maybe (Either InterpreterError ()))
-runStmt_ modules line time = handleAnyException $ timeout time $ runInterpreter $ do
-  setImports modules
-  runStmt line
 
 runChecks :: MonadIO m => Environment -> RType -> UProgram -> FilterTest m Bool
 runChecks env goalType prog =

--- a/src/HooglePlus/GHCChecker.hs
+++ b/src/HooglePlus/GHCChecker.hs
@@ -141,8 +141,7 @@ check_ goal searchParams solverChan checkerChan = do
             case msg of
                 (MesgP (program, _)) -> do
                     programPassedChecks <- executeCheck program
-
-                    (++) "Checker state: " . show <$> get >>= log
+                    show <$> get >>= log
                     if programPassedChecks then bypass >> next else next
                 (MesgClose _) -> bypass
                 _ -> bypass >> next

--- a/src/HooglePlus/GHCChecker.hs
+++ b/src/HooglePlus/GHCChecker.hs
@@ -1,5 +1,5 @@
 module HooglePlus.GHCChecker (
-    runGhcChecks, parseStrictnessSig, checkStrictness') where
+    runGhcChecks, parseStrictnessSig, checkStrictness', check) where
 
 import Language.Haskell.Interpreter
 
@@ -44,6 +44,9 @@ import Text.Printf
 import Text.Regex
 import Var
 import Data.UUID.V4
+import Control.Concurrent.Chan
+import Control.Monad.Trans.State
+import Control.Concurrent
 
 showGhc :: (Outputable a) => a -> String
 showGhc = showPpr unsafeGlobalDynFlags
@@ -120,6 +123,35 @@ checkStrictness tyclassCount body sig modules =
     handle
         (\(SomeException _) -> return False)
         (checkStrictness' tyclassCount body sig modules)
+
+check :: Goal -> SearchParams -> Chan Message -> Chan Message -> IO ()
+check goal searchParams solverChan checkerChan = catch
+    (evalStateT (check_ goal searchParams solverChan checkerChan) emptyFilterState)
+    (\err ->
+        writeChan checkerChan (MesgLog 0 "error" (show err)) >>
+        writeChan checkerChan (MesgClose (CSError err)))
+
+check_ :: MonadIO m => Goal -> SearchParams -> Chan Message -> Chan Message -> FilterTest m ()
+check_ goal searchParams solverChan checkerChan = do
+    msg <- liftIO $ readChan solverChan
+    handleMessages solverChan checkerChan msg
+    return ()
+    where
+        handleMessages solverChan checkChan msg =
+            case msg of
+                (MesgP (program, _)) -> do
+                    programPassedChecks <- executeCheck program
+                    if programPassedChecks then back >> next else next
+                (MesgClose _) -> back
+                _ -> back >> next
+
+            where
+                next = (liftIO . readChan) solverChan >>= handleMessages solverChan checkerChan
+                back = liftIO $ writeChan checkerChan msg
+
+        (env, destType) = preprocessEnvFromGoal goal
+        executeCheck = runGhcChecks searchParams env destType
+
 
 -- validate type signiture, run demand analysis, and run filter test
 -- checks the end result type checks; all arguments are used; and that the program will not immediately fail

--- a/src/HooglePlus/GHCChecker.hs
+++ b/src/HooglePlus/GHCChecker.hs
@@ -128,7 +128,7 @@ check :: Goal -> SearchParams -> Chan Message -> Chan Message -> IO ()
 check goal searchParams solverChan checkerChan = catch
     (evalStateT (check_ goal searchParams solverChan checkerChan) emptyFilterState)
     (\err ->
-        writeChan checkerChan (MesgLog 0 "error" (show err)) >>
+        writeChan checkerChan (MesgLog 0 "filterCheck" ("error: " ++ show err)) >>
         writeChan checkerChan (MesgClose (CSError err)))
 
 check_ :: MonadIO m => Goal -> SearchParams -> Chan Message -> Chan Message -> FilterTest m ()
@@ -149,7 +149,7 @@ check_ goal searchParams solverChan checkerChan = do
             where
                 next = (liftIO . readChan) solverChan >>= handleMessages solverChan checkerChan
                 bypass = liftIO $ writeChan checkerChan msg
-                log msg = liftIO $ writeChan checkerChan (MesgLog 0 "checker" msg)
+                log msg = liftIO $ writeChan checkerChan (MesgLog 3 "checker" msg)
 
         (env, destType) = preprocessEnvFromGoal goal
         executeCheck = runGhcChecks searchParams env destType

--- a/src/PetriNet/PNSolver.hs
+++ b/src/PetriNet/PNSolver.hs
@@ -678,14 +678,8 @@ findProgram env dst st ps
         solutions <- gets $ view currentSolutions
         mapping <- gets $ view nameMapping
         let code' = recoverNames mapping code
-        disableDemand <- getExperiment disableDemand
-        disableRele <- getExperiment disableRelevancy
         params <- gets $ view searchParams
-        fState <- gets $ view filterState
-        (passedCheck, fState') <-
-            withTime TypeCheckTime (liftIO $ runStateT (runGhcChecks params env dst code') fState)
-        modify $ set filterState fState'
-        if (code' `elem` solutions) || not passedCheck
+        if (code' `elem` solutions) 
             then return Nothing
             else return $ Just code'
 

--- a/src/Types/Filtering.hs
+++ b/src/Types/Filtering.hs
@@ -49,11 +49,12 @@ instance Show FunctionSignature where
         constraintsExpr = (intercalate ", " . map show) constraints
         argsExpr = (intercalate " -> " . map show) (argsType ++ [returnType])
 
+type SampleResultItem = (String, String)
 data SampleResult = SampleResult
-  { _inputs :: [String], _results :: [[String]]}
+  { _inputs :: [String], _results :: [[SampleResultItem]]}
   deriving (Eq, Show)
 
-data FilterState = FilterState
+newtype FilterState = FilterState
   { sampleResults :: Maybe SampleResult }
   deriving (Eq, Show)
 

--- a/src/Types/Filtering.hs
+++ b/src/Types/Filtering.hs
@@ -7,7 +7,7 @@ import Text.Printf
 import Data.List (intercalate)
 
 defaultTimeoutMicro = 1 * 10^6 :: Int
-defaultNumChecks = 10 :: Int
+defaultNumChecks = 5 :: Int
 defaultMaxOutputLength = 100 :: Int
 
 data ArgumentType =

--- a/src/Types/Solver.hs
+++ b/src/Types/Solver.hs
@@ -50,8 +50,7 @@ data SolverState = SolverState {
     _instanceCounts :: HashMap Id Int, -- Number of instantiations for a real-name, used in selecting representative
     _toRemove :: [Id],
     _useCount :: Map Id Int,
-    _messageChan :: Chan Message,
-    _filterState :: FilterState
+    _messageChan :: Chan Message
 } deriving(Eq)
 
 
@@ -82,8 +81,7 @@ emptySolverState = SolverState {
     _instanceCounts = HashMap.empty,
     _toRemove = [],
     _useCount = Map.empty,
-    _messageChan = undefined,
-    _filterState = emptyFilterState
+    _messageChan = undefined
 }
 
 makeLenses ''SolverState

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,15 @@
 packages:
 - .
-resolver: lts-12.4
+resolver: lts-12.26
 extra-deps:
   - table-layout-0.8.0.3
   - data-default-instances-base-0.1.0.1
   - pretty-tree-0.1.0.0
+
+compiler: ghc-8.4.4
+setup-info:
+  ghc:
+    linux64-custom-yields:
+      8.4.4:
+        url: "https://github.com/mistzzt/build-ghc-no-omit-yields/releases/download/v8.4.4/ghc-8.4.4-x86_64-unknown-linux.tar.xz"
+ghc-variant: yields

--- a/test/HooglePlus/FilterTestSpec.hs
+++ b/test/HooglePlus/FilterTestSpec.hs
@@ -36,7 +36,7 @@ testNotCrashCases =
   , ("Fail on invalid function 2", ["Data.List"], "a -> a", "\\x -> head []", False)
   , ("Fail on invalid function 3", ["Data.List"], "a -> (a, a)", "\\x -> (head [x], last [])", False)
   , ("Fail on invalid function 4", ["Data.List"], "a -> (a, a)", "\\x -> (head [x], last [])", False)
-  -- , ("Non-deterministic function", [], "Int", "last $ repeat 5", True)
+  , ("Non-deterministic function", [], "Int", "last $ repeat 5", True)
   , ("Pass w/ type class 1", [], "(Show a, Show b) => Either a b -> String", "\\x -> show x", True)]
 
 runDuplicateTest :: FilterState -> [String] -> String -> String -> IO (Bool, FilterState)


### PR DESCRIPTION
*Blocked by #38; Will be reviewed after that.*

Separate the execution of `GHCChecker` for multi-threading

- Added a new message channel for communicating between our *solver* and *checker*
- Implemented a message handler for *solver channel* to bypass messages into our *checker channel*
- Moved some functions for synthesis initialization to `Utils` to be used in checker