### PR TITLE
Integrate filter outputs into evaluation utility

### DIFF
--- a/app/HooglePlus.hs
+++ b/app/HooglePlus.hs
@@ -263,8 +263,9 @@ executeSearch synquidParams searchParams query = do
           return env
 
     handleMessages ch (MesgClose _) = putStrLn "Search complete" >> return ()
-    handleMessages ch (MesgP (program, stats)) = do
+    handleMessages ch (MesgP (program, stats, state)) = do
       printf "[writeStats]: %s\n" (show stats)
+      printf "[writeFilter]: %s\n" (show state)
       printSolution program >> readChan ch >>= (handleMessages ch)
     handleMessages ch (MesgS debug) = do
       printf "[writeStats]: %s\n" (show debug)

--- a/benchmark/BConfig.hs
+++ b/benchmark/BConfig.hs
@@ -13,6 +13,7 @@ defaultExperiment = TrackTypesAndTransitions
 expTyGarQ = "TYGAR-Q"
 expTyGarQBNoDmd = expTyGarQB ++ "-no-demand"
 expTyGarQBNoRel = expTyGarQB ++ "-no-relevancy"
+expTyGarQBNoFlt = expTyGarQB ++ "-no-filter"
 expTyGarQNoCoalesce = expTyGarQ ++ "-no-coalescing"
 expTyGarQCoalesceFirst = expTyGarQ ++ "-coalesce naive"
 expTyGarQCoalesceLeast = expTyGarQ ++ "-coalesce least"
@@ -31,6 +32,7 @@ expTyGarQBInc = "TyGarQB-Incremental"
 expILP = "Integer Linear Programming"
 
 searchParamsTyGarQ = defaultSearchParams
+searchParamsTyGarQBNoFlt = searchParamsTyGarQB{_disableFilter = True}
 searchParamsTyGarQBNoDmd = searchParamsTyGarQB{_disableDemand = True}
 searchParamsTyGarQBNoRel = searchParamsTyGarQB{_disableDemand = True, _disableRelevancy = True}
 searchParamsSypetClone = defaultSearchParams{_refineStrategy=SypetClone}

--- a/benchmark/BTypes.hs
+++ b/benchmark/BTypes.hs
@@ -5,6 +5,8 @@ module BTypes where
 import Types.Environment
 import Types.Experiments
 import Types.Generate
+import Types.Filtering
+import Types.Program
 
 import GHC.Generics
 import GHC.Exception
@@ -77,3 +79,5 @@ instance Show EvaluationException where
   show NotImplementedException = "Not Implemented"
   show (RuntimeException _) = "Runtime error"
 instance Exception EvaluationException
+
+type RunnerResult = (Either EvaluationException (Maybe (RProgram, FilterState)), TimeStatistics)

--- a/benchmark/Runner.hs
+++ b/benchmark/Runner.hs
@@ -5,6 +5,7 @@ import BConfig
 import Types.Program
 import Types.Environment
 import Types.Experiments
+import Types.Filtering
 import Synquid.Util
 import HooglePlus.Synthesize
 import Database.Environment
@@ -97,7 +98,10 @@ writeResult setup (env, envName, q, params, paramName) xs = do
       showResult (Right Nothing) = "No Solution"
       showResult (Right (Just (soln, _))) = toHaskellSolution $ show soln
 
-      showState (Right (Just (_, fs))) = show fs
+      showState (Right (Just (_, FilterState (Just sr)))) = intercalate "\n" lines
+        where
+          lines = map show results
+          results = _results sr
       showState _ = ""
 
       showRow (errOrMbProg, times) =

--- a/benchmark/Runner.hs
+++ b/benchmark/Runner.hs
@@ -98,10 +98,10 @@ writeResult setup (env, envName, q, params, paramName) xs = do
       showResult (Right Nothing) = "No Solution"
       showResult (Right (Just (soln, _))) = toHaskellSolution $ show soln
 
-      showState (Right (Just (_, FilterState (Just sr)))) = intercalate "\n" lines
+      showState (Right (Just (_, FilterState (Just sr)))) = intercalate "\t" lines
         where
-          lines = map show results
-          results = _results sr
+          lines = map (\(i, o) -> printf "%s -> %s" i o) results
+          results = head $ _results sr
       showState _ = ""
 
       showRow (errOrMbProg, times) =

--- a/src/HooglePlus/FilterTest.hs
+++ b/src/HooglePlus/FilterTest.hs
@@ -186,7 +186,7 @@ checkSolutionNotCrash modules sigStr body = or <$> liftIO executeCheck
       result <- evalHOF_ modules inits expression defaultTimeoutMicro
 
       case result of
-        Nothing -> putStrLn "Timeout in running always-fail detection" >> return True
+        Nothing -> putStrLn "Timeout in running always-fail detection" >> return False
         Just (Left err) -> putStrLn (displayException err) >> return False
         Just (Right res) -> return (seq res True)
 

--- a/src/HooglePlus/FilterTest.hs
+++ b/src/HooglePlus/FilterTest.hs
@@ -249,8 +249,14 @@ checkDuplicates modules sigStr body = do
         evalWithArg input = 
           let (inits, arg) = formatGenInputInitialization input in
           liftM2 (,)
-            (pure arg)
-            (show <$> evalHOF_ modules inits (fmtFunction_ body (show funcSig) arg) defaultTimeoutMicro) 
+            (pure $ formatArg arg)
+            (show . formatEval <$> evalHOF_ modules inits (fmtFunction_ body (show funcSig) arg) defaultTimeoutMicro) 
+          where
+            formatArg = take defaultMaxArgShowLength
+
+            formatEval Nothing = "timeout"
+            formatEval (Just (Left error)) = "error: " ++ show error
+            formatEval (Just (Right result)) = result
         
 
   where

--- a/src/PetriNet/PNSolver.hs
+++ b/src/PetriNet/PNSolver.hs
@@ -718,7 +718,7 @@ writeSolution code = do
     loc <- gets $ view currentLoc
     msgChan <- gets $ view messageChan
     let stats' = stats {pathLength = loc}
-    liftIO $ writeChan msgChan (MesgP (code, stats'))
+    liftIO $ writeChan msgChan (MesgP (code, stats', undefined))
     writeLog 1 "writeSolution" $ text (show stats')
 
 recoverNames :: Map Id Id -> Program t -> Program t

--- a/src/Types/Experiments.hs
+++ b/src/Types/Experiments.hs
@@ -7,6 +7,7 @@ import Types.Program
 import Synquid.Program
 import Synquid.Error
 import Types.Common
+import Types.Filtering
 
 -- import Control.Monad.List
 import Data.Data
@@ -116,7 +117,7 @@ data ExperimentCourse
 
 data Message
   = MesgClose CloseStatus
-  | MesgP (RProgram, TimeStatistics) -- Program with the stats associated with generating it
+  | MesgP (RProgram, TimeStatistics, FilterState) -- Program with the stats associated with generating it
   | MesgS TimeStatistics
   | MesgLog Int String String -- Log level, tag, message
 

--- a/src/Types/Filtering.hs
+++ b/src/Types/Filtering.hs
@@ -6,9 +6,11 @@ import Data.Typeable
 import Text.Printf
 import Data.List (intercalate)
 
-defaultTimeoutMicro = 1 * 10^6 :: Int
+defaultTimeoutMicro = 2 * 10^6 :: Int
 defaultNumChecks = 5 :: Int
 defaultMaxOutputLength = 100 :: Int
+
+defaultMaxArgShowLength = 15 :: Int
 
 formatHigherOrderArgument = printf "(hof_%d)" :: Int -> String
 

--- a/src/Types/Filtering.hs
+++ b/src/Types/Filtering.hs
@@ -34,7 +34,7 @@ instance Show ArgumentType where
   show (Concrete    name) = name
   show (Polymorphic name) = name
   show (ArgTypeList sub)  = printf "[%s]" (show sub)
-  show (ArgTypeApp  l r)  = printf "(%s) %s"  (show l) (show r)
+  show (ArgTypeApp  l r)  = printf "((%s) (%s))"  (show l) (show r)
   show (ArgTypeTuple types) =
     (printf "(%s)" . intercalate ", " . map show) types
   show (ArgTypeFunc src dst) = printf "((%s) -> (%s))" (show src) (show dst)

--- a/test/HooglePlus/FilterTestSpec.hs
+++ b/test/HooglePlus/FilterTestSpec.hs
@@ -61,7 +61,7 @@ testNotCrashCases =
   , ("Fail on invalid function 2", ["Data.List"], "a -> a", "\\x -> head []", False)
   , ("Fail on invalid function 3", ["Data.List"], "a -> (a, a)", "\\x -> (head [x], last [])", False)
   , ("Fail on invalid function 4", ["Data.List"], "a -> (a, a)", "\\x -> (head [x], last [])", False)
-  , ("Non-deterministic function", [], "Int", "last $ repeat 5", True)
+  , ("Non-deterministic function", [], "Int", "last $ repeat 5", False)
   , ("Pass w/ type class 1", [], "(Show a, Show b) => Either a b -> String", "\\x -> show x", True)]
 
 testNotCrashHOFs :: [(String, [String], String, String, Bool)]

--- a/webapp/src/Search.hs
+++ b/webapp/src/Search.hs
@@ -38,7 +38,7 @@ runQuery queryOpts = do
           }
       }
       collectResults ch res (MesgClose _) = return res
-      collectResults ch res (MesgP (program, _)) = readChan ch >>= (collectResults ch (program:res))
+      collectResults ch res (MesgP (program, _, _)) = readChan ch >>= (collectResults ch (program:res))
       collectResults ch res _ = readChan ch >>= (collectResults ch res)
 
 postSearchR :: Handler Html


### PR DESCRIPTION
- `Evaluation` now prints a new column for all filter-generated inputs and outputs.