### PR TITLE
Migrate FilterTest to property-based test by QuickCheck

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+    "name": "H+ w/ HIE(G) 0.11",
+    "image": "mistzzt/hoogle_plus_dev:latest",
+
+    "extensions": [
+        "eamodio.gitlens",
+        "alanz.vscode-hie-server",
+        "aaron-bond.better-comments"
+    ]
+}

--- a/InternalTypeGen.hs
+++ b/InternalTypeGen.hs
@@ -1,10 +1,25 @@
 {-# LANGUAGE FlexibleInstances #-}
 module InternalTypeGen where
 
-import Test.QuickCheck hiding (quickCheck)
+import Test.QuickCheck.Arbitrary
 import Test.QuickCheck.Gen
+import qualified Test.ChasingBottoms as CB
 import Data.Map (Map)
+import Data.List (isInfixOf)
 import Control.Applicative
+
+isEqualResult lhs rhs = case (lhs, rhs) of
+  (CB.Value a, CB.Value b) -> a == b
+  (CB.NonTermination, CB.NonTermination) -> True
+  (CB.Exception a, CB.Exception b) -> show a == show b
+  _ -> False
+
+isFailedResult result = case result of
+  CB.NonTermination -> True
+  CB.Exception _ -> True
+  CB.Value a | isInfixOf "_|_" a -> True
+  CB.Value a | isInfixOf "Exception" a -> True
+  _ -> False
 
 newtype Internal a = Val a
 

--- a/InternalTypeGen.hs
+++ b/InternalTypeGen.hs
@@ -11,7 +11,7 @@ import Control.Applicative
 isEqualResult lhs rhs = case (lhs, rhs) of
   (CB.Value a, CB.Value b) -> a == b
   (CB.NonTermination, CB.NonTermination) -> True
-  (CB.Exception a, CB.Exception b) -> show a == show b
+  (CB.Exception _, CB.Exception _) -> True
   _ -> False
 
 isFailedResult result = case result of

--- a/InternalTypeGen.hs
+++ b/InternalTypeGen.hs
@@ -17,8 +17,8 @@ isEqualResult lhs rhs = case (lhs, rhs) of
 isFailedResult result = case result of
   CB.NonTermination -> True
   CB.Exception _ -> True
-  CB.Value a | isInfixOf "_|_" a -> True
-  CB.Value a | isInfixOf "Exception" a -> True
+  CB.Value a | "_|_" `isInfixOf` a -> True
+  CB.Value a | "Exception" `isInfixOf` a -> True
   _ -> False
 
 newtype Internal a = Val a
@@ -36,4 +36,4 @@ instance {-# OVERLAPPING #-} Arbitrary (Internal Char) where
   arbitrary = Val <$> choose ('A', 'D')
 
 instance {-# OVERLAPPING #-} Arbitrary (Internal String) where
-  arbitrary = Val <$> vectorOf 5 (choose ('A', 'D')) 
+  arbitrary = Val <$> vectorOf 5 (choose ('A', 'D'))

--- a/app/HooglePlus.hs
+++ b/app/HooglePlus.hs
@@ -263,8 +263,9 @@ executeSearch synquidParams searchParams query = do
           return env
 
     handleMessages ch (MesgClose _) = putStrLn "Search complete" >> return ()
-    handleMessages ch (MesgP (program, stats)) = do
+    handleMessages ch (MesgP (program, stats, state)) = do
       printf "[writeStats]: %s\n" (show stats)
+      printf "[writeFilter]: %s\n" (show state)
       printSolution program >> readChan ch >>= (handleMessages ch)
     handleMessages ch (MesgS debug) = do
       printf "[writeStats]: %s\n" (show debug)

--- a/benchmark/Runner.hs
+++ b/benchmark/Runner.hs
@@ -132,8 +132,8 @@ collectResults ch xs (MesgClose (CSError err)) = let
     _ -> emptyTimeStats
   in return ((Left errTy, stats):xs)
 collectResults ch res@((Left err, _):_) _ = return res
-collectResults ch ((Right Nothing, _):xs) (MesgP (p, ts)) = printSolution p >> readChan ch >>= collectResults ch ((Right $ Just p, ts):xs)
-collectResults ch xs (MesgP (p, ts)) = printSolution p >> readChan ch >>= collectResults ch ((Right $ Just p, ts):xs)
+collectResults ch ((Right Nothing, _):xs) (MesgP (p, ts, _)) = printSolution p >> readChan ch >>= collectResults ch ((Right $ Just p, ts):xs)
+collectResults ch xs (MesgP (p, ts, _)) = printSolution p >> readChan ch >>= collectResults ch ((Right $ Just p, ts):xs)
 collectResults ch ((Right Nothing, _):xs) (MesgS ts) = readChan ch >>= collectResults ch ((Right Nothing, ts):xs)
 collectResults ch xs (MesgS ts) = readChan ch >>= collectResults ch ((Right Nothing, ts):xs)
 collectResults ch xs _ = readChan ch >>= collectResults ch xs

--- a/package.yaml
+++ b/package.yaml
@@ -64,6 +64,7 @@ dependencies:
 - vector
 - uuid
 - QuickCheck
+- ChasingBottoms
 
 library:
   source-dirs:

--- a/src/HooglePlus/FilterTest.hs
+++ b/src/HooglePlus/FilterTest.hs
@@ -186,7 +186,7 @@ checkSolutionNotCrash modules sigStr body = or <$> liftIO executeCheck
       result <- evalHOF_ modules inits expression defaultTimeoutMicro
 
       case result of
-        Nothing -> putStrLn "Timeout in running always-fail detection" >> return True
+        Nothing -> putStrLn "Timeout in running always-fail detection" >> return False
         Just (Left err) -> putStrLn (displayException err) >> return False
         Just (Right res) -> return (seq res True)
 
@@ -249,8 +249,13 @@ checkDuplicates modules sigStr body = do
         evalWithArg input = 
           let (inits, arg) = formatGenInputInitialization input in
           liftM2 (,)
-            (pure arg)
-            (show <$> evalHOF_ modules inits (fmtFunction_ body (show funcSig) arg) defaultTimeoutMicro) 
+            (pure $ formatArg arg)
+            (show . formatEval <$> evalHOF_ modules inits (fmtFunction_ body (show funcSig) arg) defaultTimeoutMicro)
+          where
+            formatArg = take defaultMaxArgShowLength
+            formatEval Nothing = "timeout"
+            formatEval (Just (Left error)) = "error: " ++ show error
+            formatEval (Just (Right result)) = result
         
 
   where

--- a/src/HooglePlus/FilterTest.hs
+++ b/src/HooglePlus/FilterTest.hs
@@ -220,17 +220,17 @@ checkSolutionNotCrash modules sigStr body = liftIO executeCheck
 
 checkDuplicates :: MonadIO m => [String] -> String -> String -> FilterTest m Bool
 checkDuplicates modules sigStr solution = do
-  FilterState inputs solns <- get
+  FilterState is solns <- get
 
   result <- liftIO $ compareSolution modules solution solns funcSig defaultTimeoutMicro
 
   case result of
     Left err -> do
       liftIO $ print err
-      modify $ const FilterState {inputs = inputs, solutions = solution:solns}
+      modify $ const FilterState {inputs = is, solutions = solution:solns}
       return True
     Right Failure{failingTestCase = c} -> do
-      modify $ const FilterState {inputs = show c : inputs, solutions = solution:solns}
+      modify $ const FilterState {inputs = c:is, solutions = solution:solns}
       return True
     _ -> return False
 

--- a/src/PetriNet/PNSolver.hs
+++ b/src/PetriNet/PNSolver.hs
@@ -718,7 +718,7 @@ writeSolution code = do
     loc <- gets $ view currentLoc
     msgChan <- gets $ view messageChan
     let stats' = stats {pathLength = loc}
-    liftIO $ writeChan msgChan (MesgP (code, stats'))
+    liftIO $ writeChan msgChan (MesgP (code, stats', undefined))
     writeLog 1 "writeSolution" $ text (show stats')
 
 recoverNames :: Map Id Id -> Program t -> Program t

--- a/src/Types/Experiments.hs
+++ b/src/Types/Experiments.hs
@@ -7,6 +7,7 @@ import Types.Program
 import Synquid.Program
 import Synquid.Error
 import Types.Common
+import Types.Filtering
 
 -- import Control.Monad.List
 import Data.Data
@@ -116,7 +117,7 @@ data ExperimentCourse
 
 data Message
   = MesgClose CloseStatus
-  | MesgP (RProgram, TimeStatistics) -- Program with the stats associated with generating it
+  | MesgP (RProgram, TimeStatistics, FilterState) -- Program with the stats associated with generating it
   | MesgS TimeStatistics
   | MesgLog Int String String -- Log level, tag, message
 

--- a/src/Types/Filtering.hs
+++ b/src/Types/Filtering.hs
@@ -6,9 +6,10 @@ import Data.Typeable
 import Text.Printf
 import Data.List (intercalate)
 
-defaultTimeoutMicro = 1 * 10^6 :: Int
+defaultTimeoutMicro = 2 * 10^6 :: Int
 defaultNumChecks = 5 :: Int
 defaultMaxOutputLength = 100 :: Int
+defaultMaxArgShowLength = 15 :: Int
 
 formatHigherOrderArgument = printf "(hof_%d)" :: Int -> String
 
@@ -32,7 +33,7 @@ instance Show ArgumentType where
   show (Concrete    name) = name
   show (Polymorphic name) = name
   show (ArgTypeList sub)  = printf "[%s]" (show sub)
-  show (ArgTypeApp  l r)  = printf "(%s) %s"  (show l) (show r)
+  show (ArgTypeApp  l r)  = printf "((%s) (%s))"  (show l) (show r)
   show (ArgTypeTuple types) =
     (printf "(%s)" . intercalate ", " . map show) types
   show (ArgTypeFunc src dst) = printf "((%s) -> (%s))" (show src) (show dst)

--- a/src/Types/Filtering.hs
+++ b/src/Types/Filtering.hs
@@ -7,13 +7,8 @@ import Text.Printf
 import Data.List (intercalate)
 
 defaultTimeoutMicro = 5 * 10^4 :: Int
-defaultNumChecks = 5 :: Int
 defaultMaxOutputLength = 100 :: Int
-defaultMaxArgShowLength = 15 :: Int
 
-toParamListDecl n = unwords
-  $ zipWith (curry fst) [printf "arg_%d" index :: String | index <- [0..] :: [Int]] [0..(n - 1)]
-formatHigherOrderArgument = printf "(hof_%d)" :: Int -> String
 quickCheckModules =
   zip [ "Test.QuickCheck"
   , "Test.QuickCheck.Gen"
@@ -76,16 +71,6 @@ instance Show FunctionSignature where
         constraintsExpr = (intercalate ", " . map show) constraints
         argsExpr = (intercalate " -> " . map show) (argsType ++ [returnType])
 
-data GeneratedArg =
-    Value String
-  | HigherOrder String Int Int Int
-  deriving (Eq)
-
-instance Show GeneratedArg where
-  show (Value val) = val
-  show (HigherOrder _ index _ _) = formatHigherOrderArgument index
-
-type GeneratedInput = [GeneratedArg]
 data FilterState = FilterState {
   inputs :: [String],
   solutions :: [String]

--- a/src/Types/Filtering.hs
+++ b/src/Types/Filtering.hs
@@ -7,7 +7,7 @@ import Text.Printf
 import Data.List (intercalate)
 
 defaultTimeoutMicro = 5 * 10^4 :: Int
-defaultInterpreterTimeoutMicro = 20 * 10^6 :: Int
+defaultInterpreterTimeoutMicro = 60 * 10^6 :: Int
 defaultMaxOutputLength = 100 :: Int
 
 quickCheckModules =

--- a/src/Types/Filtering.hs
+++ b/src/Types/Filtering.hs
@@ -7,7 +7,7 @@ import Text.Printf
 import Data.List (intercalate)
 
 defaultTimeoutMicro = 5 * 10^4 :: Int
-defaultInterpreterTimeoutMicro = 6 * 10^6 :: Int
+defaultInterpreterTimeoutMicro = 20 * 10^6 :: Int
 defaultMaxOutputLength = 100 :: Int
 
 quickCheckModules =
@@ -73,7 +73,7 @@ instance Show FunctionSignature where
         argsExpr = (intercalate " -> " . map show) (argsType ++ [returnType])
 
 data FilterState = FilterState {
-  inputs :: [String],
+  inputs :: [[String]],
   solutions :: [String]
 } deriving (Eq, Show)
 

--- a/src/Types/Filtering.hs
+++ b/src/Types/Filtering.hs
@@ -7,6 +7,7 @@ import Text.Printf
 import Data.List (intercalate)
 
 defaultTimeoutMicro = 5 * 10^4 :: Int
+defaultInterpreterTimeoutMicro = 6 * 10^6 :: Int
 defaultMaxOutputLength = 100 :: Int
 
 quickCheckModules =

--- a/test/HooglePlus/FilterTestSpec.hs
+++ b/test/HooglePlus/FilterTestSpec.hs
@@ -27,9 +27,8 @@ itDupCase (desc, modules, tipe, (main: rest), shouldPass) =
   it desc $ do
     (ret, st) <- runDuplicateTest emptyFilterState modules tipe main
 
-    -- base case: generate input and pass
+    -- base case: pass
     ret `shouldBe` True
-    st `shouldNotBe` (FilterState Nothing) 
 
     -- inductive case on new solutions
     mapM_ (f ret st tipe) rest
@@ -60,7 +59,7 @@ testNotCrashCases =
   , ("Fail on invalid function 1", ["Data.Maybe"], "a -> a", "\\x -> fromJust Nothing", False)
   , ("Fail on invalid function 2", ["Data.List"], "a -> a", "\\x -> head []", False)
   , ("Fail on invalid function 3", ["Data.List"], "a -> (a, a)", "\\x -> (head [x], last [])", False)
-  , ("Fail on invalid function 4", ["Data.List"], "a -> (a, a)", "\\x -> (head [x], last [])", False)
+  , ("Fail on invalid function 4", ["Data.List"], "a -> (a, a)", "\\x -> (head [], last [x])", False)
   , ("Non-deterministic function", [], "Int", "last $ repeat 5", False)
   , ("Pass w/ type class 1", [], "(Show a, Show b) => Either a b -> String", "\\x -> show x", True)]
 

--- a/test/HooglePlus/FilterTestSpec.hs
+++ b/test/HooglePlus/FilterTestSpec.hs
@@ -55,7 +55,7 @@ testNotCrashCases =
   , ("Succeed on infinite functions", ["GHC.List"], "a -> [a]", "\\x -> repeat x", True)
   , ("Succeed on var w/ module names", ["GHC.List"],
      "[a] -> [b] -> [[(a,b)]]",
-     "\\arg0 -> GHC.List.repeat (GHC.List.zip arg1 arg0)", True)
+     "\\arg0 arg1 -> GHC.List.repeat (GHC.List.zip arg1 arg0)", True)
   , ("Fail on invalid function 1", ["Data.Maybe"], "a -> a", "\\x -> fromJust Nothing", False)
   , ("Fail on invalid function 2", ["Data.List"], "a -> a", "\\x -> head []", False)
   , ("Fail on invalid function 3", ["Data.List"], "a -> (a, a)", "\\x -> (head [x], last [])", False)

--- a/test/HooglePlus/FilterTestSpec.hs
+++ b/test/HooglePlus/FilterTestSpec.hs
@@ -53,9 +53,9 @@ testNotCrashCases =
   , ("Succeed on poly function w/o type constrains 2", [], "(a, b) -> b", "\\(x, y) -> y", True)
   , ("Succeed on poly function w/o type constrains 3", [], "(a, Either Int Int) -> Int", "\\(_, t) -> either id id t", True)
   , ("Succeed on infinite functions", ["GHC.List"], "a -> [a]", "\\x -> repeat x", True)
-  , ("Succeed on var w/ module names", ["GHC.Int", "Data.ByteString.Lazy", "Data.ByteString.Builder"],
-     "GHC.Int.Int64 -> Data.ByteString.Lazy.ByteString",
-     "\\arg0 -> Data.ByteString.Builder.toLazyByteString (Data.ByteString.Builder.int64Dec arg0)", True)
+  , ("Succeed on var w/ module names", ["GHC.List"],
+     "[a] -> [b] -> [[(a,b)]]",
+     "\\arg0 -> GHC.List.repeat (GHC.List.zip arg1 arg0)", True)
   , ("Fail on invalid function 1", ["Data.Maybe"], "a -> a", "\\x -> fromJust Nothing", False)
   , ("Fail on invalid function 2", ["Data.List"], "a -> a", "\\x -> head []", False)
   , ("Fail on invalid function 3", ["Data.List"], "a -> (a, a)", "\\x -> (head [x], last [])", False)

--- a/test/HooglePlus/FilterTestSpec.hs
+++ b/test/HooglePlus/FilterTestSpec.hs
@@ -61,7 +61,7 @@ testNotCrashCases =
   , ("Fail on invalid function 2", ["Data.List"], "a -> a", "\\x -> head []", False)
   , ("Fail on invalid function 3", ["Data.List"], "a -> (a, a)", "\\x -> (head [x], last [])", False)
   , ("Fail on invalid function 4", ["Data.List"], "a -> (a, a)", "\\x -> (head [x], last [])", False)
-  , ("Non-deterministic function", [], "Int", "last $ repeat 5", True)
+  , ("Non-deterministic function", [], "Int", "last $ repeat 5", False)
   , ("Pass w/ type class 1", [], "(Show a, Show b) => Either a b -> String", "\\x -> show x", True)]
 
 testNotCrashHOFs :: [(String, [String], String, String, Bool)]

--- a/webapp/src/Search.hs
+++ b/webapp/src/Search.hs
@@ -38,7 +38,7 @@ runQuery queryOpts = do
           }
       }
       collectResults ch res (MesgClose _) = return res
-      collectResults ch res (MesgP (program, _)) = readChan ch >>= (collectResults ch (program:res))
+      collectResults ch res (MesgP (program, _, _)) = readChan ch >>= (collectResults ch (program:res))
       collectResults ch res _ = readChan ch >>= (collectResults ch res)
 
 postSearchR :: Handler Html


### PR DESCRIPTION
- Improved performance and capability for a larger set of test inputs. (Previously ~1s for one single test, and now ~2s for test with a default size 100)
- Test inputs now can be shrunk to a smaller size and is more readable.
- Higher-order arguments can be pretty-printed like described below.
- We're able to distinguish different kinds of solutions and hopefully it would help ranking:
```haskell
data FunctionCrashKind = 
    AlwaysSucceed
  | AlwaysFail
  | PartialFunction
  deriving (Show)
```

Example:
<img width="450" alt="image" src="https://user-images.githubusercontent.com/12794966/68521328-d60e6f00-0254-11ea-9064-b52c2d28fc47.png">
In the picture, note that we have a minimal counterexample generated by QuickCheck to differentiate two solutions. (It's quite verbose now since I failed to turn off QuickCheck's output on console, but..)

_Some explanation on the last commit (6bb7b8c4cf8):_
I removed the unit test with `ByteString` since it doesn't work with [ChasingBottoms](http://hackage.haskell.org/package/ChasingBottoms), a package which gives approximate results on partial/infinite functions. It's weird but I guess it will not break other functionalities.

```haskell
> let fb = \arg0 -> Data.ByteString.Builder.toLazyByteString (Data.ByteString.Builder.int64Dec arg0)
> fb 333
"333"
> approxShow 100 (fb 333)
"*** Exception: Data.ByteString.Lazy.ByteString.toConstr
CallStack (from HasCallStack):
  error, called at libraries/bytestring/Data/ByteString/Lazy/Internal.hs:113:20 in bytestring-0.10.8.2:Data.ByteString.Lazy.Internal
```