### PR TITLE
Use smallcheck as the backend of the test-based filter

### DIFF
--- a/InternalTypeGen.hs
+++ b/InternalTypeGen.hs
@@ -4,11 +4,11 @@ import Data.List (isInfixOf)
 
 import qualified Test.ChasingBottoms as CB
 
-isEqualResult lhs rhs = case (lhs, rhs) of
-  (CB.Value a, CB.Value b) -> a == b
-  (CB.NonTermination, CB.NonTermination) -> True
-  (CB.Exception _, CB.Exception _) -> True
-  _ -> False
+instance Eq a => Eq (CB.Result a) where
+  (CB.Value a) == (CB.Value b) = a == b
+  CB.NonTermination == CB.NonTermination = True
+  (CB.Exception _) == (CB.Exception _) = True
+  _ == _ = False
 
 isFailedResult result = case result of
   CB.NonTermination -> True

--- a/InternalTypeGen.hs
+++ b/InternalTypeGen.hs
@@ -1,17 +1,6 @@
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE UndecidableInstances #-}
-
 module InternalTypeGen where
 
-import Control.Applicative
-import Control.Monad
 import Data.List (isInfixOf)
-import Data.Map (Map)
-import Data.Universe hiding (Show)
-
-import Test.QuickCheck.Arbitrary
-import Test.QuickCheck.Gen
-import Test.QuickCheck.Gen.Unsafe (promote)
 
 import qualified Test.ChasingBottoms as CB
 
@@ -27,38 +16,3 @@ isFailedResult result = case result of
   CB.Value a | "_|_" `isInfixOf` a -> True
   CB.Value a | "Exception" `isInfixOf` a -> True
   _ -> False
-
-newtype Internal a = Val a deriving Eq
-instance Functor Internal where fmap f (Val v) = Val (f v)
-instance Applicative Internal where
-  pure = Val
-  Val f <*> Val x = Val (f x)
-instance Monad Internal where
-  (Val v) >>= f = f v
-  return = Val
-instance Show a => Show (Internal a) where
-  show (Val value) = show value
-
-instance Arbitrary a => Arbitrary (Internal a) where
-  arbitrary = pure <$> arbitrary
-instance CoArbitrary a => CoArbitrary (Internal a) where
-  coarbitrary (Val n) = coarbitrary n
-
-instance {-# OVERLAPPING #-} Arbitrary (Internal Int) where
-  arbitrary = pure <$> choose (0, 4)
-instance {-# OVERLAPPING #-} Arbitrary (Internal Char) where
-  arbitrary = pure <$> choose ('a', 'd')
-instance {-# OVERLAPPING #-} Arbitrary (Internal String) where
-  arbitrary = pure <$> listOf (choose ('a', 'd'))
-
--- finite values
-
-instance Universe (Internal Int) where universe = map pure [0..4]
-instance Universe (Internal Char) where universe = map pure ['a'..'d']
-
-instance Universe (Internal a) => Universe (Internal [a]) where
-  universe = map sequence (powerset universe)
-    where powerset = filterM (const [True, False])
-
-instance Universe (Internal a) => Finite (Internal a) where
-  universeF = universe

--- a/package.yaml
+++ b/package.yaml
@@ -51,7 +51,6 @@ dependencies:
 - pretty-simple
 - pretty-tree
 - process
-- QuickCheck
 - regex-compat
 - regex-posix
 - resourcet
@@ -64,7 +63,6 @@ dependencies:
 - time
 - transformers
 - transformers-compat
-- universe
 - unordered-containers
 - uuid
 - vector

--- a/package.yaml
+++ b/package.yaml
@@ -56,6 +56,7 @@ dependencies:
 - regex-posix
 - resourcet
 - safe
+- smallcheck
 - sort
 - split
 - stm
@@ -63,11 +64,11 @@ dependencies:
 - time
 - transformers
 - transformers-compat
+- universe
 - unordered-containers
 - uuid
 - vector
 - z3
-- universe
 
 library:
   source-dirs:

--- a/src/HooglePlus/FilterTest.hs
+++ b/src/HooglePlus/FilterTest.hs
@@ -103,37 +103,31 @@ buildNotCrashProp solution funcSig =
       [ printf "let %s %s = monadic (%s <$> %s %s) in" propName argDecl body "wrappedSolution" argLine
       , printf "smallCheckM 10 (%s)" propName]) :: String
 
-buildDupCheckProp :: (String, [String]) -> FunctionSignature -> Int -> String
-buildDupCheckProp (sol, otherSols) funcSig timeInMicro =
+buildDupCheckProp :: (String, [String]) -> FunctionSignature -> Int -> Int -> String
+buildDupCheckProp (sol, otherSols) funcSig timeInMicro depth =
 
-  unwords [wrapperLhs, unwords wrapperSols, formatProp wrapperLhs wrapperSols argLine argDecl]
+  unwords [wrapperLhs, unwords wrapperSols, formatProp]
   where
     (argLine, argDecl) = toParamListDecl (_argsType funcSig)
     solutionType = show funcSig
 
-    wrapFunc name sol = buildFunctionWrapper' name sol solutionType argLine timeInMicro
-
-    otherSols' = zip [0..] otherSols
+    otherSols' = zip [0..] otherSols :: [(Int, String)]
     wrapperLhs = wrapFunc "lhs" sol
-    wrapperSols = map (\(i, sol) -> wrapFunc (printf "sol_%d" i) sol) otherSols'
+    wrapperSols = map (\(i, sol) -> wrapFunc (printf "result_%d" i) sol) otherSols'
 
-    formatBinding :: (Int, String) -> String
-    formatBinding (i, _) = printf "result_%d <- run (sol_%d %s);" i i argLine :: String
-
-    formatBindingItem :: (Int, String) -> String
-    formatBindingItem (i, _) = printf "result_%d" i :: String
-
-    formatBindingList sols =
-      let items = intercalate "," $ map formatBindingItem sols in
-        printf "[%s]" items :: String
-
-    formatProp wLhs wRhs argLine argDecl = unwords
-      ([ printf "let dupProp %s = monadic $ do {" argDecl 
-      , printf "resultL <- run (lhs %s);" argLine]
-        ++ map formatBinding otherSols' ++
-      [ printf "assert (Prelude.or $ Prelude.map (isEqualResult resultL) %s)" (formatBindingList otherSols')
+    formatProp = unwords
+      [ printf "let dupProp = exists $ \\%s -> monadic $ do {" argDecl
+      , printf "evaluated <- mapM (\\f -> f %s) (%s);" argLine (formatResultList otherSols')
+      , printf "resultL <- lhs %s;" argLine
+      , printf "return $ not (resultL `elem` evaluated)"
       , "} in"
-      , printf "quickCheckWithResult stdArgs { chatty = False } dupProp"]) :: String
+      , printf "smallCheckM %d dupProp" depth] :: String
+
+    wrapFunc name sol = buildFunctionWrapper' name sol solutionType argLine timeInMicro
+    formatResultList results =
+      let items = intercalate "," $ map format results in
+        printf "[%s]" items :: String
+      where format (i, _) = printf "result_%d" i :: String
 
 runInterpreter' :: Int -> InterpreterT IO a -> IO (Either InterpreterError a) 
 runInterpreter' timeInMicro exec =
@@ -174,11 +168,11 @@ validateSolution modules solution funcSig time = do
     caseToString (Just (CounterExample args _)) = unwords args
 
 compareSolution :: [String] -> String -> [String] -> FunctionSignature -> Int -> IO (Either InterpreterError SmallCheckResult)
-compareSolution modules solution otherSolutions funcSig time = do
+compareSolution modules solution otherSolutions funcSig time =
   runInterpreter' defaultInterpreterTimeoutMicro $ do
     setImportsQ (zip modules (repeat Nothing) ++ frameworkModules)
 
-    let prop = buildDupCheckProp (solution, otherSolutions) funcSig time
+    let prop = buildDupCheckProp (solution, otherSolutions) funcSig time defaultDepth
     interpret prop (as :: IO SmallCheckResult) >>= liftIO
 
 runChecks :: MonadIO m => Environment -> RType -> UProgram -> FilterTest m Bool
@@ -217,11 +211,13 @@ checkDuplicates modules sigStr solution = do
   result <- liftIO $ compareSolution modules solution solns funcSig defaultTimeoutMicro
 
   case result of
+    Left (UnknownError "timeout") -> return False
     Left err -> do
       liftIO $ print err
       modify $ const fs {solutions = solution:solns}
       return True
-    Right (Just (CounterExample args _)) -> do
+    Right (Just NotExist) -> return False
+    Right Nothing -> do
       modify $ const fs {inputs = ["todo"]:is, solutions = solution:solns}
       return True
     _ -> return False
@@ -240,28 +236,10 @@ toParamListDecl args =
 
     plainArgLine = unwords $ map (formatParam . fst) indexedArgs
     declArgLine = unwords $ map toDecl indexedArgs
-    
-    computeAppDepth (ArgTypeFunc l r) =
-      case r of
-        ArgTypeFunc _ _ -> 1 + computeAppDepth r
-        _ -> 1
-    computeAppDepth invalid = error $ printf "Invalid argument for computeAppDepth: %s" (show invalid)
 
     formatParam = printf "arg_%d" :: Int -> String
 
     toDecl :: (Int, ArgumentType) -> String
-    toDecl (index, tipe@(ArgTypeFunc l r)) =
-
-      printf "(%s arg_%d)" pattern index
-      where
-        pattern = case computeAppDepth tipe of
-          1 -> "Fn"
-          2 -> "Fn2"
-          3 -> "Fn3"
-          _ -> error "Unsupported higher-order function"
-    
-    -- todo: previously we use _Universal_ to restrict range
-    -- but now we don't necessarily need it. Consider remove
     toDecl (index, _) = printf "(arg_%d)" index
       
       

--- a/src/HooglePlus/FilterTest.hs
+++ b/src/HooglePlus/FilterTest.hs
@@ -191,7 +191,7 @@ runChecks env goalType prog =
 checkSolutionNotCrash :: MonadIO m => [String] -> String -> String -> FilterTest m Bool
 checkSolutionNotCrash modules sigStr body = do
   fs@(FilterState _ _ samples) <- get
-  result <- liftIO $ executeCheck
+  result <- liftIO executeCheck
 
   let (pass, desc) = case result of
                           Left err -> (True, UnableToCheck (show err))

--- a/src/Types/Filtering.hs
+++ b/src/Types/Filtering.hs
@@ -9,8 +9,8 @@ import Data.List (intercalate)
 import Test.SmallCheck.Drivers
 
 defaultTimeoutMicro = 5 * 10^4 :: Int
-defaultDepth = 3 :: Int
-defaultInterpreterTimeoutMicro = 5 * 10^6 :: Int
+defaultDepth = 2 :: Int
+defaultInterpreterTimeoutMicro = 3 * 10^6 :: Int
 defaultMaxOutputLength = 100 :: Int
 
 frameworkModules =
@@ -20,6 +20,7 @@ frameworkModules =
   ++ [("Test.ChasingBottoms", Just "CB")]
 
 type SmallCheckResult = Maybe PropertyFailure
+type DistinguishedInput = (String, String)
 
 data FunctionCrashDesc = 
     AlwaysSucceed String
@@ -76,7 +77,7 @@ instance Show FunctionSignature where
         argsExpr = (intercalate " -> " . map show) (argsType ++ [returnType])
 
 data FilterState = FilterState {
-  inputs :: [[String]],
+  inputs :: [DistinguishedInput],
   solutions :: [String],
   solutionExamples :: [(String, FunctionCrashDesc)]
 } deriving (Eq, Show)

--- a/src/Types/Filtering.hs
+++ b/src/Types/Filtering.hs
@@ -9,8 +9,8 @@ import Data.List (intercalate)
 import Test.SmallCheck.Drivers
 
 defaultTimeoutMicro = 5 * 10^4 :: Int
-defaultDepth = 2 :: Int
-defaultInterpreterTimeoutMicro = 3 * 10^6 :: Int
+defaultDepth = 3 :: Int
+defaultInterpreterTimeoutMicro = 2 * 10^6 :: Int
 defaultMaxOutputLength = 100 :: Int
 
 frameworkModules =

--- a/src/Types/Filtering.hs
+++ b/src/Types/Filtering.hs
@@ -9,7 +9,8 @@ import Data.List (intercalate)
 import Test.SmallCheck.Drivers
 
 defaultTimeoutMicro = 5 * 10^4 :: Int
-defaultInterpreterTimeoutMicro = 4 * 10^6 :: Int
+defaultDepth = 3 :: Int
+defaultInterpreterTimeoutMicro = 5 * 10^6 :: Int
 defaultMaxOutputLength = 100 :: Int
 
 frameworkModules =

--- a/src/Types/Filtering.hs
+++ b/src/Types/Filtering.hs
@@ -6,18 +6,19 @@ import Data.Typeable
 import Text.Printf
 import Data.List (intercalate)
 
+import Test.SmallCheck.Drivers
+
 defaultTimeoutMicro = 5 * 10^4 :: Int
 defaultInterpreterTimeoutMicro = 4 * 10^6 :: Int
 defaultMaxOutputLength = 100 :: Int
 
-quickCheckModules =
-  zip [ "Test.QuickCheck"
-  , "Test.QuickCheck.Gen"
-  , "Test.QuickCheck.Random"
-  , "Test.QuickCheck.Monadic"
-  , "Text.Show.Functions" ] (repeat Nothing)
+frameworkModules =
+  zip [ "Test.SmallCheck"
+  , "Test.SmallCheck.Drivers" ] (repeat Nothing)
 
   ++ [("Test.ChasingBottoms", Just "CB")]
+
+type SmallCheckResult = Maybe PropertyFailure
 
 data FunctionCrashDesc = 
     AlwaysSucceed String


### PR DESCRIPTION
### Updates

- Timeout is more precise: previously we discard any result from a timeout-ed QuickCheck process, but now we can get the result even smallcheck timeout-ed.
- Better test cases: enumeration of all values vs. random generation
- Simpler implementation: we don't have to restrict the range of data types manually anymore; we use `Depth` parameter now

### Implementation
- Eliminate Invalids: previous guideline but replaced random generation to value enumeration.
- Eliminate Duplicates: assert the existence of the set of inputs $I$ that distinguish the synthesized result against all other results. 

### Next steps
- Extend example generation to have more examples: we now only have one
- Run benchmarks over the previous query set