### PR TITLE
Input-output examples generation

### DIFF
--- a/InternalTypeGen.hs
+++ b/InternalTypeGen.hs
@@ -1,8 +1,11 @@
+{-# LANGUAGE FlexibleInstances, MultiParamTypeClasses #-}
 module InternalTypeGen where
 
 import Data.List (isInfixOf)
 
+import qualified Test.LeanCheck.Function.ShowFunction as SF
 import qualified Test.ChasingBottoms as CB
+import qualified Test.SmallCheck.Series as SS
 
 instance Eq a => Eq (CB.Result a) where
   (CB.Value a) == (CB.Value b) = a == b
@@ -16,3 +19,8 @@ isFailedResult result = case result of
   CB.Value a | "_|_" `isInfixOf` a -> True
   CB.Value a | "Exception" `isInfixOf` a -> True
   _ -> False
+
+newtype Inner a = Inner a deriving (Eq)
+instance SS.Serial m a => SS.Serial m (Inner a) where series = SS.newtypeCons Inner
+instance (SF.ShowFunction a) => Show (Inner a) where
+  show (Inner fcn) = SF.showFunctionLine 4 fcn

--- a/app/HooglePlus.hs
+++ b/app/HooglePlus.hs
@@ -28,6 +28,7 @@ import HooglePlus.Stats
 import Types.Encoder
 import HooglePlus.GHCChecker
 import HooglePlus.Utils
+import Types.Filtering
 
 import Control.Monad
 import Control.Lens ((^.))
@@ -264,7 +265,7 @@ executeSearch synquidParams searchParams query = do
     handleMessages ch (MesgP (program, stats, fs)) = do
       when (logLevel > 0) $ printf "[writeStats]: %s\n" (show stats)
       printSolution program
-      printFilter fs
+      putStrLn $ printFilter fs
       hFlush stdout
       readChan ch >>= (handleMessages ch)
     handleMessages ch (MesgS debug) = do

--- a/package.yaml
+++ b/package.yaml
@@ -41,6 +41,7 @@ dependencies:
 - http-conduit
 - http-types
 - indents
+- leancheck
 - lens
 - logict
 - MissingH

--- a/src/HooglePlus/Utils.hs
+++ b/src/HooglePlus/Utils.hs
@@ -118,8 +118,9 @@ printFilter (FilterState ((s_1, s_2):xs) _ ((_, x): _)) = do
 printFilter (FilterState _ _ ((_, x):_)) = putStrLn $ "Sample behavior: " ++ show x
 -}
 
-printIO [] = "error????"
-printIO xs = printf "%s ==> %s" (unwords $ init xs) (last xs)
+printIO :: IOExample -> String
+printIO ([], _) = "error????"
+printIO (is, os) = printf "%s ==> %s" (unwords is) os
 
 printFilter (FilterState _ _ samples) = intercalate "\n" (map printOneSol sampleMap)
     where

--- a/src/HooglePlus/Utils.hs
+++ b/src/HooglePlus/Utils.hs
@@ -110,22 +110,15 @@ printSolution solution = do
     putStrLn $ "SOLUTION: " ++ toHaskellSolution (show solution)
     putStrLn "************************************************"
 
-{-
-printFilter (FilterState [] [] []) = return ()
-printFilter (FilterState ((s_1, s_2):xs) _ ((_, x): _)) = do
-    putStrLn $ "Sample behavior: " ++ show x
-    putStrLn $ "Differentiated input: " ++ s_1 ++ " and " ++ s_2
-printFilter (FilterState _ _ ((_, x):_)) = putStrLn $ "Sample behavior: " ++ show x
--}
-
 printIO :: IOExample -> String
 printIO ([], _) = "error????"
 printIO (is, os) = printf "%s ==> %s" (unwords is) os
 
-printFilter (FilterState _ _ samples) = intercalate "\n" (map printOneSol sampleMap)
+printFilter (FilterState _ solns samples) = intercalate "\n" (map printOneSol sampleMap)
     where
         sampleGroup = groupBy (\x y -> fst x == fst y) (sortOn fst samples)
         sampleMap = map ((\(x, y) -> (head x, nub y)) . unzip) sampleGroup 
+        sampleMap' = filter (\(s, _) -> s `elem` solns) sampleMap
         printOneSol (s, ios) = printf "%s\n%s" s (unlines $ map printIO ios)
 
 extractSolution :: Environment -> RType -> UProgram -> ([String], String, String, [(Id, RSchema)])

--- a/src/Types/Filtering.hs
+++ b/src/Types/Filtering.hs
@@ -23,17 +23,17 @@ type SmallCheckResult = Maybe PropertyFailure
 type DistinguishedInput = (String, String)
 
 data FunctionCrashDesc = 
-    AlwaysSucceed String
-  | AlwaysFail String
-  | PartialFunction String String
-  | UnableToCheck String
+    AlwaysSucceed [String]
+  | AlwaysFail [String]
+  | PartialFunction [String] [String]
+  | UnableToCheck [String]
   deriving (Eq)
 
 instance Show FunctionCrashDesc where
-  show (AlwaysSucceed i) = "Total: " ++ i
-  show (AlwaysFail i) = "Fail: " ++ i
-  show (PartialFunction s f) = "Partial: succeeds on " ++ s ++ "; fails on " ++ f
-  show (UnableToCheck ex) = "Exception: " ++ ex
+  show (AlwaysSucceed i) = "Total: " ++ show i
+  show (AlwaysFail i) = "Fail: " ++ show i
+  show (PartialFunction s f) = "Partial: succeeds on " ++ show s ++ "; fails on " ++ show f
+  show (UnableToCheck ex) = "Exception: " ++ show ex
 
 data ArgumentType =
     Concrete    String
@@ -79,7 +79,7 @@ instance Show FunctionSignature where
 data FilterState = FilterState {
   inputs :: [DistinguishedInput],
   solutions :: [String],
-  solutionExamples :: [(String, FunctionCrashDesc)]
+  solutionExamples :: [(String, [String])]
 } deriving (Eq, Show)
 
 emptyFilterState = FilterState {

--- a/src/Types/Filtering.hs
+++ b/src/Types/Filtering.hs
@@ -15,7 +15,9 @@ defaultMaxOutputLength = 100 :: Int
 
 frameworkModules =
   zip [ "Test.SmallCheck"
-  , "Test.SmallCheck.Drivers" ] (repeat Nothing)
+  , "Test.SmallCheck.Drivers"
+  , "Test.LeanCheck.Function.ShowFunction"
+  , "Control.Exception" ] (repeat Nothing)
 
   ++ [("Test.ChasingBottoms", Just "CB")]
 

--- a/src/Types/Filtering.hs
+++ b/src/Types/Filtering.hs
@@ -20,19 +20,28 @@ frameworkModules =
   ++ [("Test.ChasingBottoms", Just "CB")]
 
 type SmallCheckResult = Maybe PropertyFailure
-type DistinguishedInput = (String, String)
+
+-- [arg0, arg1, arg2, ...] :: SampleInput
+type SampleInput = [String]
+
+-- sample input generated during duplicate-check phase
+-- currently we can only generate two as a tuple
+type DistinguishedInput = (SampleInput, SampleInput)
+
+-- input-output pair
+type IOExample = (SampleInput, String)
 
 data FunctionCrashDesc = 
-    AlwaysSucceed [String]
-  | AlwaysFail [String]
-  | PartialFunction [String] [String]
-  | UnableToCheck [String]
+    AlwaysSucceed SampleInput
+  | AlwaysFail SampleInput
+  | PartialFunction SampleInput SampleInput
+  | UnableToCheck SampleInput
   deriving (Eq)
 
 instance Show FunctionCrashDesc where
-  show (AlwaysSucceed i) = "Total: " ++ show i
-  show (AlwaysFail i) = "Fail: " ++ show i
-  show (PartialFunction s f) = "Partial: succeeds on " ++ show s ++ "; fails on " ++ show f
+  show (AlwaysSucceed i) = "Total: " ++ (unwords i)
+  show (AlwaysFail i) = "Fail: " ++ (unwords i)
+  show (PartialFunction s f) = "Partial: succeeds on " ++ (unwords s) ++ "; fails on " ++ (unwords f)
   show (UnableToCheck ex) = "Exception: " ++ show ex
 
 data ArgumentType =
@@ -79,7 +88,7 @@ instance Show FunctionSignature where
 data FilterState = FilterState {
   inputs :: [DistinguishedInput],
   solutions :: [String],
-  solutionExamples :: [(String, [String])]
+  solutionExamples :: [(String, IOExample)]
 } deriving (Eq, Show)
 
 emptyFilterState = FilterState {


### PR DESCRIPTION
- [x] First-order duplicate check support
- [x] Higher-order function support

### Preview
```haskell
(\arg0 -> GHC.List.head (GHC.List.init arg0))
[0] ==> Prelude.head: empty list
[1] ==> Prelude.head: empty list
[0,0] ==> 0

(\arg0 -> GHC.List.head arg0)
[0] ==> 0
[1] ==> 1
[0,1] ==> 0
[1,0] ==> 1
[] ==> Prelude.head: empty list

(\arg0 -> GHC.List.last arg0)
[0] ==> 0
[1] ==> 1
[0,1] ==> 1
[1,0] ==> 0
```

next:
- fix: HOF not correctly parsed from output
- fix: strange "dynamic linker not inited" error from GHC
- todo: remove redundant GHC calls
- todo: separate example generation from `validateSolution` phase
- optimize: generate & run solution on the first time, instead of having a new phase