### PR TITLE
Issue #49

### DIFF
--- a/src/Synquid/Parser.hs
+++ b/src/Synquid/Parser.hs
@@ -127,7 +127,7 @@ fixIndex (FunctionT n a r) =
           else
             0))
     else 
-      0
+      max (fixIndex a) (fixIndex r)
 fixIndex _ = 0
 
 fixArgName :: Int -> RType -> RType

--- a/src/Synquid/Parser.hs
+++ b/src/Synquid/Parser.hs
@@ -135,11 +135,9 @@ fixArgName _ typ = let (_, res) = fixArgName' ((fixIndex typ) + 1) typ in res
   where
     fixArgName' idx (FunctionT x tArg tRes)
       | x == "" = let
-          -- (idx', tArg') = fixArgName' (idx + 1) tArg
           (idx'', tRes') = fixArgName' (idx + 1) tRes
           in (idx'', FunctionT ("arg"++show idx) tArg tRes')
       | otherwise = let
-          -- (idx', tArg') = fixArgName' idx tArg
           (idx'', tRes') = fixArgName' idx tRes
           in (idx'', FunctionT x tArg tRes')
     fixArgName' idx t = (idx, t)
@@ -263,7 +261,6 @@ parseFunctionTypeWithArg = do
 
 -- | Parse top-level type that does not start with an argument name
 -- and thus could be a scalar or a function type depending on whether followed by ->
-----------------------------------------------------------------------------------------------------------------------------------------------------
 parseFunctionTypeMb = do
   argType <- parseUnrefTypeWithArgs <|> parseTypeAtom
   parseFunctionRest argType <|> return argType

--- a/webapp/src/Search.hs
+++ b/webapp/src/Search.hs
@@ -174,6 +174,7 @@ transformSolution goal queryResult = do
                                     _ -> ([], tt)
                 (constraints, t') = allTyclass t
                 in "(" ++ intercalate ", " constraints ++ ") => " ++ showGoal t'
+            | x == "" = showGoal tArg ++ " -> " ++ showGoal tRes
             | otherwise = x ++ ": " ++ showGoal tArg ++ " -> " ++ showGoal tRes
         showGoal t = show t
 

--- a/webapp/src/templates/homepage.hamlet
+++ b/webapp/src/templates/homepage.hamlet
@@ -9,7 +9,7 @@
     <div .body>
         <div .left>
             <form id="theForm" method=post action="search">
-                <input #signature type=text, class="form-control", placeholder="Search by type singature!">
+                <input #signature type=text, class="form-control", placeholder="Search by type signature!">
                 <button .btn .btn-outline-primary type="submit" id="button-addon2">
                     Search
                 <button .btn .btn-outline-primary type="button" id="button-stop">


### PR DESCRIPTION
Fixed issue with arg naming: The arguments of higher-order query arguments are never used in the solution, and hence should not be given names automatically.

Also, fixed another issue with arg naming wherein a query something like: [a] -> arg0: ([a] -> Int) -> [a] would get renamed to argo0: [a] -> arg0: ([a] -> Int) -> [a] upon search. Now it gets renamed to arg1: [a] -> arg0: ([a] -> Int) -> [a]