### PR TITLE
fix stop button issues

### DIFF
--- a/web_server/run_webserver.sh
+++ b/web_server/run_webserver.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-export FLASK_APP=hplus
-export FLASK_ENV=development
-flask run


### PR DESCRIPTION
The stop button didn't work.

- send SIGKILL instead of SIGTERM
- sessions weren't working for some reason. I didn't have time to figure it out.
  - Uses an expiring dictionary to map UUID -> PID. Expires after 120 seconds.
- Adds a dependencies.txt file so you know what you need to run the middle layer.