### PR TITLE
Optimize not failing check and implement more examples

### DIFF
--- a/InternalTypeGen.hs
+++ b/InternalTypeGen.hs
@@ -69,8 +69,8 @@ evaluateIO timeInMicro inputs vals = do
 
     eval val = io (evalStr val)
  
-waitState :: Int -> [String] -> CB.Result String -> ExampleGeneration IO Bool
-waitState numIOs args ret = case (not $ isFailedResult ret) of
+waitState :: Int -> [String] -> [String] -> CB.Result String -> ExampleGeneration IO Bool
+waitState numIOs args previous ret = case (not $ isFailedResult ret) of
   False -> pure False
   _ -> do
     ioState <- get
@@ -80,4 +80,4 @@ waitState numIOs args ret = case (not $ isFailedResult ret) of
 
     state <- get
     return ((length state) == numIOs)
-  where isNotInState ret state = not $ ret `elem` (map output state)
+  where isNotInState retStr state = not $ ((retStr `elem` (map output state)) || (retStr `elem` previous))

--- a/src/HooglePlus/FilterTest.hs
+++ b/src/HooglePlus/FilterTest.hs
@@ -301,9 +301,9 @@ toParamListDecl args =
 
 -- ******** Example Generator ********
 
-generateIOPairs :: [String] -> String -> FunctionSignature -> Int -> Int -> Depth -> IO (Either InterpreterError GeneratorResult) 
-generateIOPairs modules solution funcSig numPairs timeInMicro depth = 
-  runInterpreter' defaultInterpreterTimeoutMicro $ do
+generateIOPairs :: [String] -> String -> FunctionSignature -> Int -> Int -> Int -> Depth -> IO (Either InterpreterError GeneratorResult) 
+generateIOPairs modules solution funcSig numPairs timeInMicro interpreterTimeInMicro depth = 
+  runInterpreter' interpreterTimeInMicro $ do
     setImportsQ (zip modules (repeat Nothing) ++ frameworkModules)
     interpret property (as :: IO GeneratorResult) >>= liftIO
 

--- a/src/HooglePlus/FilterTest.hs
+++ b/src/HooglePlus/FilterTest.hs
@@ -301,8 +301,8 @@ toParamListDecl args =
 
 -- ******** Example Generator ********
 
-generateIOPairs :: [String] -> String -> FunctionSignature -> Int -> Int -> Int -> Depth -> IO (Either InterpreterError GeneratorResult) 
-generateIOPairs modules solution funcSig numPairs timeInMicro interpreterTimeInMicro depth = 
+generateIOPairs :: [String] -> String -> FunctionSignature -> Int -> Int -> Int -> Depth -> [String] -> IO (Either InterpreterError GeneratorResult) 
+generateIOPairs modules solution funcSig numPairs timeInMicro interpreterTimeInMicro depth existingResults = 
   runInterpreter' interpreterTimeInMicro $ do
     setImportsQ (zip modules (repeat Nothing) ++ frameworkModules)
     interpret property (as :: IO GeneratorResult) >>= liftIO
@@ -321,7 +321,8 @@ generateIOPairs modules solution funcSig numPairs timeInMicro interpreterTimeInM
 
         formatProp (argLine, argDecl, argShow) wrappedSolution = unwords
           [ wrappedSolution
-          , printf "let prop %s = monadic ((wrappedSolution %s) >>= (waitState %d %s)) in" argDecl argLine numPairs argShow
+          , printf "let previousResults = [%s] in" (intercalate ", " $ map show existingResults)
+          , printf "let prop %s = monadic ((wrappedSolution %s) >>= (waitState %d %s previousResults)) in" argDecl argLine numPairs argShow
           , printf "execStateT (smallCheckM %d (exists prop)) []" depth] :: String
 
     buildWrapper solution typeStr params timeInMicro =

--- a/src/Types/Filtering.hs
+++ b/src/Types/Filtering.hs
@@ -11,7 +11,7 @@ import Test.SmallCheck.Drivers
 
 defaultTimeoutMicro = 5 * 10^4 :: Int
 defaultDepth = 5 :: Int
-defaultInterpreterTimeoutMicro = 2 * 10^6 :: Int
+defaultInterpreterTimeoutMicro = 4 * 10^6 :: Int
 defaultMaxOutputLength = 10 :: Int 
 
 frameworkModules =

--- a/src/Types/Filtering.hs
+++ b/src/Types/Filtering.hs
@@ -26,15 +26,7 @@ frameworkModules =
   ++ [("Test.ChasingBottoms", Just "CB")]
 
 type SmallCheckResult = (Maybe PropertyFailure, [Example])
-type GeneratorResult = [String]
-type DiffInstance = ([String], [String])
-
--- [arg0, arg1, arg2, ...] :: SampleInput
-type SampleInput = [String]
-
--- sample input generated during duplicate-check phase
--- currently we can only generate two as a tuple
-type DistinguishedInput = (SampleInput, SampleInput)
+type GeneratorResult = [Example]
 
 type AssociativeExamples = [(String, [Example])]
 
@@ -93,10 +85,10 @@ instance Show FunctionSignature where
         argsExpr = (intercalate " -> " . map show) (argsType ++ [returnType])
 
 data FilterState = FilterState {
-  inputs :: [DistinguishedInput],
+  inputs :: [[String]],
   solutions :: [String],
   solutionExamples :: [(String, FunctionCrashDesc)],
-  differentiateExamples :: [Example]
+  differentiateExamples :: [(String, Example)]
 } deriving (Eq, Show)
 
 emptyFilterState = FilterState {


### PR DESCRIPTION
- Code cleanup
- `FilterState.differentiateExamples` records the solution as well
- Fixed undefined in state evaluation
- Removed `alwaysSucceed` property when validating candidates